### PR TITLE
Add unicode to latex source

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,5 @@ All credit goes to the creators of those files.
 - [emoji](https://www.unicode.org/Public/emoji/13.1/emoji-test.txt)
 - [kaomoji](https://github.com/kuanyui/kaomoji.el/blob/master/kaomoji-data.el)
 - [math](https://raw.githubusercontent.com/wspr/unicode-math/ef5688f303d7010138632ab45ef2440d3ca20ee5/unicode-math-table.tex)
-- [latex](https://raw.githubusercontent.com/wspr/unicode-math/ef5688f303d7010138632ab45ef2440d3ca20ee5/unicode-math-table.tex)
+- [latex](https://milde.users.sourceforge.net/LUCR/Math/data/unimathsymbols.txt)
 - [gitmoji](https://gitmoji.dev/api/gitmojis)

--- a/data/telescope-sources/latex.json
+++ b/data/telescope-sources/latex.json
@@ -1,9786 +1,9818 @@
 [
   [
-    "\\mathexclam",
-    "exclamation mark"
+    "!",
+    "! exclamation mark"
   ],
   [
-    "\\mathoctothorpe",
-    "number sign"
+    "\\#",
+    "# # \\# (oz), number sign"
   ],
   [
-    "\\mathdollar",
-    "dollar sign"
+    "\\$",
+    "$ = \\mathdollar, dollar sign"
   ],
   [
-    "\\mathpercent",
-    "percent sign"
+    "\\%",
+    "% percent sign"
   ],
   [
-    "\\mathampersand",
-    "ampersand"
+    "\\&",
+    "& # \\binampersand (stmaryrd)"
   ],
   [
-    "\\lparen",
-    "left parenthesis"
+    "(",
+    "( left parenthesis"
   ],
   [
-    "\\rparen",
-    "right parenthesis"
+    ")",
+    ") right parenthesis"
   ],
   [
-    "\\mathplus",
-    "plus sign b:"
+    "*",
+    "* # \\ast, (high) asterisk, star"
   ],
   [
-    "\\mathcomma",
-    "comma"
+    "+",
+    "+ plus sign"
   ],
   [
-    "\\mathperiod",
-    "full stop, period"
+    ",",
+    ", comma"
   ],
   [
-    "\\mathslash",
-    "solidus"
+    ".",
+    ". full stop, period"
   ],
   [
-    "\\mathcolon",
-    "colon"
+    "/",
+    "/ # \\slash, solidus"
   ],
   [
-    "\\mathsemicolon",
-    "semicolon p:"
+    ":",
+    ": = \\colon (literal), colon (not ratio)"
   ],
   [
-    "\\less",
-    "less-than sign r:"
+    ";",
+    "; semicolon p:"
   ],
   [
-    "\\equal",
-    "equals sign r:"
+    "<",
+    "< less-than sign r:"
   ],
   [
-    "\\greater",
-    "greater-than sign r:"
+    "=",
+    "= equals sign r:"
   ],
   [
-    "\\mathquestion",
-    "question mark"
+    ">",
+    "> greater-than sign r:"
   ],
   [
-    "\\mathatsign",
-    "commercial at"
+    "?",
+    "? question mark"
   ],
   [
     "\\lbrack",
-    "left square bracket"
+    "[ left square bracket"
   ],
   [
     "\\backslash",
-    "reverse solidus"
+    "\\ reverse solidus"
   ],
   [
     "\\rbrack",
-    "right square bracket"
+    "] right square bracket"
   ],
   [
-    "\\lbrace",
-    "left curly bracket"
+    "N",
+    "  circumflex accent, tex superscript operator"
   ],
   [
-    "\\vert",
-    "vertical bar"
+    "\\_",
+    "_ low line, tex subscript operator"
   ],
   [
-    "\\rbrace",
-    "right curly bracket"
+    "\\{",
+    "{ = \\lbrace, left curly bracket"
   ],
   [
-    "\\mathsterling",
-    "pound sign"
+    "|",
+    "| = \\vert, vertical bar"
   ],
   [
-    "\\mathyen",
-    "yen sign"
+    "\\}",
+    "} = \\rbrace, right curly bracket"
+  ],
+  [
+    "\\sptilde",
+    "~ # \\sim, tilde"
+  ],
+  [
+    "\\cent",
+    "¢ = \\mathcent (txfonts), cent"
+  ],
+  [
+    "\\pounds",
+    "£ = \\mathsterling (txfonts), pound sign, fourier prints a dollar sign"
+  ],
+  [
+    "\\yen",
+    "¥ yen sign"
   ],
   [
     "\\mathsection",
-    "section symbol"
+    "§  sect"
+  ],
+  [
+    "\\spddot",
+    "¨ dot /die, alias for 0308"
   ],
   [
     "\\neg",
-    "/neg /lnot not sign"
+    "¬ = \\lnot, not sign"
+  ],
+  [
+    "\\circledR",
+    "® registered sign"
+  ],
+  [
+    "\\degree",
+    "°  deg"
   ],
   [
     "\\pm",
-    "plus-or-minus sign"
+    "± plus-or-minus sign"
   ],
   [
-    "\\mathparagraph",
-    "paragraph symbol"
+    "\\Micro",
+    "µ = \\tcmu (mathcomp), t \\textmu (textcomp), # \\mathrm{\\mu} (omlmathrm), # \\muup (kpfonts mathdesign), micro sign"
+  ],
+  [
+    "\\P",
+    "¶  para (paragraph sign, pilcrow)"
   ],
   [
     "\\cdotp",
-    "/centerdot b: middle dot"
+    "·  # \\cdot, x \\centerdot, b: middle dot"
+  ],
+  [
+    "\textquestiondown",
+    "¿  iquest"
   ],
   [
     "\\times",
-    "multiply sign"
+    "× multiplication sign, z notation cartesian product"
   ],
   [
-    "\\matheth",
-    "eth"
+    "\\eth",
+    "ð eth"
   ],
   [
     "\\div",
-    "divide sign"
-  ],
-  [
-    "\\Zbar",
-    "impedance (latin capital letter z with stroke)"
-  ],
-  [
-    "\\grave",
-    "grave accent"
-  ],
-  [
-    "\\acute",
-    "acute accent"
-  ],
-  [
-    "\\hat",
-    "circumflex accent"
-  ],
-  [
-    "\\widehat",
-    "circumflex accent"
-  ],
-  [
-    "\\tilde",
-    "tilde"
-  ],
-  [
-    "\\widetilde",
-    "tilde"
-  ],
-  [
-    "\\bar",
-    "macron"
-  ],
-  [
-    "\\overbar",
-    "overbar embellishment"
-  ],
-  [
-    "\\wideoverbar",
-    "stretchy overbar embellishment"
-  ],
-  [
-    "\\breve",
-    "breve"
-  ],
-  [
-    "\\widebreve",
-    "stretchy breve"
-  ],
-  [
-    "\\dot",
-    "dot above"
-  ],
-  [
-    "\\ddot",
-    "dieresis"
-  ],
-  [
-    "\\ovhook",
-    "combining hook above"
-  ],
-  [
-    "\\ocirc",
-    "ring"
-  ],
-  [
-    "\\check",
-    "caron"
-  ],
-  [
-    "\\widecheck",
-    "stretchy caron"
-  ],
-  [
-    "\\candra",
-    "candrabindu (non-spacing)"
-  ],
-  [
-    "\\oturnedcomma",
-    "combining turned comma above"
-  ],
-  [
-    "\\ocommatopright",
-    "combining comma above right"
-  ],
-  [
-    "\\droang",
-    "left angle above (non-spacing)"
-  ],
-  [
-    "\\wideutilde",
-    "under tilde accent (multiple characters and non-spacing)"
-  ],
-  [
-    "\\mathunderbar",
-    "combining low line"
-  ],
-  [
-    "\\notaccent",
-    "combining long solidus overlay"
-  ],
-  [
-    "\\underleftrightarrow",
-    "underleftrightarrow accent"
-  ],
-  [
-    "\\mupAlpha",
-    "capital alpha, greek"
-  ],
-  [
-    "\\mupBeta",
-    "capital beta, greek"
-  ],
-  [
-    "\\mupGamma",
-    "capital gamma, greek"
-  ],
-  [
-    "\\mupDelta",
-    "capital delta, greek"
-  ],
-  [
-    "\\mupEpsilon",
-    "capital epsilon, greek"
-  ],
-  [
-    "\\mupZeta",
-    "capital zeta, greek"
-  ],
-  [
-    "\\mupEta",
-    "capital eta, greek"
-  ],
-  [
-    "\\mupTheta",
-    "capital theta, greek"
-  ],
-  [
-    "\\mupIota",
-    "capital iota, greek"
-  ],
-  [
-    "\\mupKappa",
-    "capital kappa, greek"
-  ],
-  [
-    "\\mupLambda",
-    "capital lambda, greek"
-  ],
-  [
-    "\\mupMu",
-    "capital mu, greek"
-  ],
-  [
-    "\\mupNu",
-    "capital nu, greek"
-  ],
-  [
-    "\\mupXi",
-    "capital xi, greek"
-  ],
-  [
-    "\\mupOmicron",
-    "capital omicron, greek"
-  ],
-  [
-    "\\mupPi",
-    "capital pi, greek"
-  ],
-  [
-    "\\mupRho",
-    "capital rho, greek"
-  ],
-  [
-    "\\mupSigma",
-    "capital sigma, greek"
-  ],
-  [
-    "\\mupTau",
-    "capital tau, greek"
-  ],
-  [
-    "\\mupUpsilon",
-    "capital upsilon, greek"
-  ],
-  [
-    "\\mupPhi",
-    "capital phi, greek"
-  ],
-  [
-    "\\mupChi",
-    "capital chi, greek"
-  ],
-  [
-    "\\mupPsi",
-    "capital psi, greek"
-  ],
-  [
-    "\\mupOmega",
-    "capital omega, greek"
-  ],
-  [
-    "\\mupalpha",
-    "small alpha, greek"
-  ],
-  [
-    "\\mupbeta",
-    "small beta, greek"
-  ],
-  [
-    "\\mupgamma",
-    "small gamma, greek"
-  ],
-  [
-    "\\mupdelta",
-    "small delta, greek"
-  ],
-  [
-    "\\mupvarepsilon",
-    "rounded small varepsilon, greek"
-  ],
-  [
-    "\\mupzeta",
-    "small zeta, greek"
-  ],
-  [
-    "\\mupeta",
-    "small eta, greek"
-  ],
-  [
-    "\\muptheta",
-    "straight theta, small theta, greek"
-  ],
-  [
-    "\\mupiota",
-    "small iota, greek"
-  ],
-  [
-    "\\mupkappa",
-    "small kappa, greek"
-  ],
-  [
-    "\\muplambda",
-    "small lambda, greek"
-  ],
-  [
-    "\\mupmu",
-    "small mu, greek"
-  ],
-  [
-    "\\mupnu",
-    "small nu, greek"
-  ],
-  [
-    "\\mupxi",
-    "small xi, greek"
-  ],
-  [
-    "\\mupomicron",
-    "small omicron, greek"
-  ],
-  [
-    "\\muppi",
-    "small pi, greek"
-  ],
-  [
-    "\\muprho",
-    "small rho, greek"
-  ],
-  [
-    "\\mupvarsigma",
-    "terminal sigma, greek"
-  ],
-  [
-    "\\mupsigma",
-    "small sigma, greek"
-  ],
-  [
-    "\\muptau",
-    "small tau, greek"
-  ],
-  [
-    "\\mupupsilon",
-    "small upsilon, greek"
-  ],
-  [
-    "\\mupvarphi",
-    "curly or open small phi, greek"
-  ],
-  [
-    "\\mupchi",
-    "small chi, greek"
-  ],
-  [
-    "\\muppsi",
-    "small psi, greek"
-  ],
-  [
-    "\\mupomega",
-    "small omega, greek"
-  ],
-  [
-    "\\mupvartheta",
-    "/vartheta - curly or open theta"
-  ],
-  [
-    "\\mupphi",
-    "/straightphi - small phi, greek"
-  ],
-  [
-    "\\mupvarpi",
-    "rounded small pi (pomega), greek"
-  ],
-  [
-    "\\upDigamma",
-    "capital digamma"
-  ],
-  [
-    "\\updigamma",
-    "old greek small letter digamma"
-  ],
-  [
-    "\\mupvarkappa",
-    "rounded small kappa, greek"
-  ],
-  [
-    "\\mupvarrho",
-    "rounded small rho, greek"
-  ],
-  [
-    "\\mupvarTheta",
-    "greek capital theta symbol"
-  ],
-  [
-    "\\mupepsilon",
-    "greek lunate varepsilon symbol"
-  ],
-  [
-    "\\upbackepsilon",
-    "greek reversed lunate epsilon symbol"
-  ],
-  [
-    "\\mathhyphen",
-    "hyphen"
-  ],
-  [
-    "\\horizbar",
-    "horizontal bar"
-  ],
-  [
-    "\\Vert",
-    "double vertical bar"
-  ],
-  [
-    "\\twolowline",
-    "double low line (spacing)"
-  ],
-  [
-    "\\dagger",
-    "dagger relation"
-  ],
-  [
-    "\\ddagger",
-    "double dagger relation"
-  ],
-  [
-    "\\smblkcircle",
-    "/bullet b: round bullet, filled"
-  ],
-  [
-    "\\enleadertwodots",
-    "double baseline dot (en leader)"
-  ],
-  [
-    "\\unicodeellipsis",
-    "ellipsis (horizontal)"
-  ],
-  [
-    "\\prime",
-    "prime or minute, not superscripted"
-  ],
-  [
-    "\\dprime",
-    "double prime or second, not superscripted"
-  ],
-  [
-    "\\trprime",
-    "triple prime (not superscripted)"
-  ],
-  [
-    "\\backprime",
-    "reverse prime, not superscripted"
-  ],
-  [
-    "\\backdprime",
-    "double reverse prime, not superscripted"
-  ],
-  [
-    "\\backtrprime",
-    "triple reverse prime, not superscripted"
-  ],
-  [
-    "\\caretinsert",
-    "caret (insertion mark)"
-  ],
-  [
-    "\\Exclam",
-    "double exclamation mark"
-  ],
-  [
-    "\\tieconcat",
-    "character tie, z notation sequence concatenation"
-  ],
-  [
-    "\\hyphenbullet",
-    "rectangle, filled (hyphen bullet)"
-  ],
-  [
-    "\\fracslash",
-    "fraction slash"
-  ],
-  [
-    "\\Question",
-    "double question mark"
-  ],
-  [
-    "\\closure",
-    "close up"
-  ],
-  [
-    "\\qprime",
-    "quadruple prime, not superscripted"
-  ],
-  [
-    "\\euro",
-    "euro sign"
-  ],
-  [
-    "\\leftharpoonaccent",
-    "combining left harpoon above"
-  ],
-  [
-    "\\overleftharpoon",
-    "combining left harpoon above"
-  ],
-  [
-    "\\rightharpoonaccent",
-    "combining right harpoon above"
-  ],
-  [
-    "\\overrightharpoon",
-    "combining right harpoon above"
-  ],
-  [
-    "\\vertoverlay",
-    "combining long vertical line overlay"
-  ],
-  [
-    "\\overleftarrow",
-    "combining left arrow above"
-  ],
-  [
-    "\\overrightarrow",
-    "combining left arrow above"
-  ],
-  [
-    "\\vec",
-    "combining right arrow above"
-  ],
-  [
-    "\\dddot",
-    "combining three dots above"
-  ],
-  [
-    "\\ddddot",
-    "combining four dots above"
-  ],
-  [
-    "\\enclosecircle",
-    "combining enclosing circle"
-  ],
-  [
-    "\\enclosesquare",
-    "combining enclosing square"
-  ],
-  [
-    "\\enclosediamond",
-    "combining enclosing diamond"
-  ],
-  [
-    "\\overleftrightarrow",
-    "combining left right arrow above"
-  ],
-  [
-    "\\enclosetriangle",
-    "combining enclosing upward pointing triangle"
-  ],
-  [
-    "\\annuity",
-    "combining annuity symbol"
-  ],
-  [
-    "\\threeunderdot",
-    "combining triple underdot"
-  ],
-  [
-    "\\widebridgeabove",
-    "combining wide bridge above"
-  ],
-  [
-    "\\underrightharpoondown",
-    "combining rightwards harpoon with barb downwards"
-  ],
-  [
-    "\\underleftharpoondown",
-    "combining leftwards harpoon with barb downwards"
-  ],
-  [
-    "\\underleftarrow",
-    "combining left arrow below"
-  ],
-  [
-    "\\underrightarrow",
-    "combining right arrow below"
-  ],
-  [
-    "\\asteraccent",
-    "combining asterisk above"
-  ],
-  [
-    "\\BbbC",
-    "/bbb c, open face c"
-  ],
-  [
-    "\\Eulerconst",
-    "euler constant"
-  ],
-  [
-    "\\mscrg",
-    "/scr g, script letter g"
-  ],
-  [
-    "\\mscrH",
-    "hamiltonian (script capital h)"
-  ],
-  [
-    "\\mfrakH",
-    "/frak h, upper case h"
-  ],
-  [
-    "\\BbbH",
-    "/bbb h, open face h"
-  ],
-  [
-    "\\Planckconst",
-    "planck constant"
-  ],
-  [
-    "\\hslash",
-    "/hslash - variant planck's over 2pi"
-  ],
-  [
-    "\\mscrI",
-    "/scr i, script letter i"
-  ],
-  [
-    "\\Im",
-    "imaginary part"
-  ],
-  [
-    "\\mscrL",
-    "lagrangian (script capital l)"
-  ],
-  [
-    "\\ell",
-    "cursive small l"
-  ],
-  [
-    "\\BbbN",
-    "/bbb n, open face n"
-  ],
-  [
-    "\\wp",
-    "weierstrass p"
-  ],
-  [
-    "\\BbbP",
-    "/bbb p, open face p"
-  ],
-  [
-    "\\BbbQ",
-    "/bbb q, open face q"
-  ],
-  [
-    "\\mscrR",
-    "/scr r, script letter r"
-  ],
-  [
-    "\\Re",
-    "real part"
-  ],
-  [
-    "\\BbbR",
-    "/bbb r, open face r"
-  ],
-  [
-    "\\BbbZ",
-    "/bbb z, open face z"
-  ],
-  [
-    "\\mho",
-    "conductance"
-  ],
-  [
-    "\\mfrakZ",
-    "/frak z, upper case z"
-  ],
-  [
-    "\\turnediota",
-    "turned iota"
-  ],
-  [
-    "\\Angstrom",
-    "angstrom capital a, ring"
-  ],
-  [
-    "\\mscrB",
-    "bernoulli function (script capital b)"
-  ],
-  [
-    "\\mfrakC",
-    "black-letter capital c"
-  ],
-  [
-    "\\mscre",
-    "/scr e, script letter e"
-  ],
-  [
-    "\\mscrE",
-    "/scr e, script letter e"
-  ],
-  [
-    "\\mscrF",
-    "/scr f, script letter f"
-  ],
-  [
-    "\\Finv",
-    "turned capital f"
-  ],
-  [
-    "\\mscrM",
-    "physics m-matrix (script capital m)"
-  ],
-  [
-    "\\mscro",
-    "order of (script small o)"
-  ],
-  [
-    "\\aleph",
-    "aleph, hebrew"
-  ],
-  [
-    "\\beth",
-    "beth, hebrew"
-  ],
-  [
-    "\\gimel",
-    "gimel, hebrew"
-  ],
-  [
-    "\\daleth",
-    "daleth, hebrew"
-  ],
-  [
-    "\\Bbbpi",
-    "double-struck small pi"
-  ],
-  [
-    "\\Bbbgamma",
-    "double-struck small gamma"
-  ],
-  [
-    "\\BbbGamma",
-    "double-struck capital gamma"
-  ],
-  [
-    "\\BbbPi",
-    "double-struck capital pi"
-  ],
-  [
-    "\\Bbbsum",
-    "double-struck n-ary summation"
-  ],
-  [
-    "\\Game",
-    "turned sans-serif capital g"
-  ],
-  [
-    "\\sansLturned",
-    "turned sans-serif capital l"
-  ],
-  [
-    "\\sansLmirrored",
-    "reversed sans-serif capital l"
-  ],
-  [
-    "\\Yup",
-    "turned sans-serif capital y"
-  ],
-  [
-    "\\mitBbbD",
-    "double-struck italic capital d"
-  ],
-  [
-    "\\mitBbbd",
-    "double-struck italic small d"
-  ],
-  [
-    "\\mitBbbe",
-    "double-struck italic small e"
-  ],
-  [
-    "\\mitBbbi",
-    "double-struck italic small i"
-  ],
-  [
-    "\\mitBbbj",
-    "double-struck italic small j"
-  ],
-  [
-    "\\PropertyLine",
-    "property line"
-  ],
-  [
-    "\\upand",
-    "turned ampersand"
-  ],
-  [
-    "\\leftarrow",
-    "/leftarrow /gets a: leftward arrow"
-  ],
-  [
-    "\\uparrow",
-    "upward arrow"
-  ],
-  [
-    "\\rightarrow",
-    "/rightarrow /to a: rightward arrow"
-  ],
-  [
-    "\\downarrow",
-    "downward arrow"
-  ],
-  [
-    "\\leftrightarrow",
-    "left and right arrow"
-  ],
-  [
-    "\\updownarrow",
-    "up and down arrow"
-  ],
-  [
-    "\\nwarrow",
-    "nw pointing arrow"
-  ],
-  [
-    "\\nearrow",
-    "ne pointing arrow"
-  ],
-  [
-    "\\searrow",
-    "se pointing arrow"
-  ],
-  [
-    "\\swarrow",
-    "sw pointing arrow"
-  ],
-  [
-    "\\nleftarrow",
-    "not left arrow"
-  ],
-  [
-    "\\nrightarrow",
-    "not right arrow"
-  ],
-  [
-    "\\leftwavearrow",
-    "left arrow-wavy"
-  ],
-  [
-    "\\rightwavearrow",
-    "right arrow-wavy"
-  ],
-  [
-    "\\twoheadleftarrow",
-    "left two-headed arrow"
-  ],
-  [
-    "\\twoheaduparrow",
-    "up two-headed arrow"
-  ],
-  [
-    "\\twoheadrightarrow",
-    "right two-headed arrow"
-  ],
-  [
-    "\\twoheaddownarrow",
-    "down two-headed arrow"
-  ],
-  [
-    "\\leftarrowtail",
-    "left arrow-tailed"
-  ],
-  [
-    "\\rightarrowtail",
-    "right arrow-tailed"
-  ],
-  [
-    "\\mapsfrom",
-    "maps to, leftward"
-  ],
-  [
-    "\\mapsup",
-    "maps to, upward"
-  ],
-  [
-    "\\mapsto",
-    "maps to, rightward"
-  ],
-  [
-    "\\mapsdown",
-    "maps to, downward"
-  ],
-  [
-    "\\updownarrowbar",
-    "up down arrow with base (perpendicular)"
-  ],
-  [
-    "\\hookleftarrow",
-    "left arrow-hooked"
-  ],
-  [
-    "\\hookrightarrow",
-    "right arrow-hooked"
-  ],
-  [
-    "\\looparrowleft",
-    "left arrow-looped"
-  ],
-  [
-    "\\looparrowright",
-    "right arrow-looped"
-  ],
-  [
-    "\\leftrightsquigarrow",
-    "left and right arr-wavy"
-  ],
-  [
-    "\\nleftrightarrow",
-    "not left and right arrow"
-  ],
-  [
-    "\\downzigzagarrow",
-    "downwards zigzag arrow"
-  ],
-  [
-    "\\Lsh",
-    "/lsh a:"
-  ],
-  [
-    "\\Rsh",
-    "/rsh a:"
-  ],
-  [
-    "\\Ldsh",
-    "left down angled arrow"
-  ],
-  [
-    "\\Rdsh",
-    "right down angled arrow"
-  ],
-  [
-    "\\linefeed",
-    "rightwards arrow with corner downwards"
-  ],
-  [
-    "\\carriagereturn",
-    "downwards arrow with corner leftward = carriage return"
-  ],
-  [
-    "\\curvearrowleft",
-    "left curved arrow"
-  ],
-  [
-    "\\curvearrowright",
-    "right curved arrow"
-  ],
-  [
-    "\\barovernorthwestarrow",
-    "north west arrow to long bar"
-  ],
-  [
-    "\\barleftarrowrightarrowbar",
-    "leftwards arrow to bar over rightwards arrow to bar"
-  ],
-  [
-    "\\acwopencirclearrow",
-    "anticlockwise open circle arrow"
-  ],
-  [
-    "\\cwopencirclearrow",
-    "clockwise open circle arrow"
-  ],
-  [
-    "\\leftharpoonup",
-    "left harpoon-up"
-  ],
-  [
-    "\\leftharpoondown",
-    "left harpoon-down"
-  ],
-  [
-    "\\upharpoonright",
-    "/upharpoonright /restriction a: up harpoon-right"
-  ],
-  [
-    "\\upharpoonleft",
-    "up harpoon-left"
-  ],
-  [
-    "\\rightharpoonup",
-    "right harpoon-up"
-  ],
-  [
-    "\\rightharpoondown",
-    "right harpoon-down"
-  ],
-  [
-    "\\downharpoonright",
-    "down harpoon-right"
-  ],
-  [
-    "\\downharpoonleft",
-    "down harpoon-left"
-  ],
-  [
-    "\\rightleftarrows",
-    "right arrow over left arrow"
-  ],
-  [
-    "\\updownarrows",
-    "up arrow, down arrow"
-  ],
-  [
-    "\\leftrightarrows",
-    "left arrow over right arrow"
-  ],
-  [
-    "\\leftleftarrows",
-    "two left arrows"
-  ],
-  [
-    "\\upuparrows",
-    "two up arrows"
-  ],
-  [
-    "\\rightrightarrows",
-    "two right arrows"
-  ],
-  [
-    "\\downdownarrows",
-    "two down arrows"
-  ],
-  [
-    "\\leftrightharpoons",
-    "left harpoon over right"
-  ],
-  [
-    "\\rightleftharpoons",
-    "right harpoon over left"
-  ],
-  [
-    "\\nLeftarrow",
-    "not implied by"
-  ],
-  [
-    "\\nLeftrightarrow",
-    "not left and right double arrows"
-  ],
-  [
-    "\\nRightarrow",
-    "not implies"
-  ],
-  [
-    "\\Leftarrow",
-    "is implied by"
-  ],
-  [
-    "\\Uparrow",
-    "up double arrow"
-  ],
-  [
-    "\\Rightarrow",
-    "implies"
-  ],
-  [
-    "\\Downarrow",
-    "down double arrow"
-  ],
-  [
-    "\\Leftrightarrow",
-    "left and right double arrow"
-  ],
-  [
-    "\\Updownarrow",
-    "up and down double arrow"
-  ],
-  [
-    "\\Nwarrow",
-    "nw pointing double arrow"
-  ],
-  [
-    "\\Nearrow",
-    "ne pointing double arrow"
-  ],
-  [
-    "\\Searrow",
-    "se pointing double arrow"
-  ],
-  [
-    "\\Swarrow",
-    "sw pointing double arrow"
-  ],
-  [
-    "\\Lleftarrow",
-    "left triple arrow"
-  ],
-  [
-    "\\Rrightarrow",
-    "right triple arrow"
-  ],
-  [
-    "\\leftsquigarrow",
-    "leftwards squiggle arrow"
-  ],
-  [
-    "\\rightsquigarrow",
-    "rightwards squiggle arrow"
-  ],
-  [
-    "\\nHuparrow",
-    "upwards arrow with double stroke"
-  ],
-  [
-    "\\nHdownarrow",
-    "downwards arrow with double stroke"
-  ],
-  [
-    "\\leftdasharrow",
-    "leftwards dashed arrow"
-  ],
-  [
-    "\\updasharrow",
-    "upwards dashed arrow"
-  ],
-  [
-    "\\rightdasharrow",
-    "rightwards dashed arrow"
-  ],
-  [
-    "\\downdasharrow",
-    "downwards dashed arrow"
-  ],
-  [
-    "\\barleftarrow",
-    "leftwards arrow to bar"
-  ],
-  [
-    "\\rightarrowbar",
-    "rightwards arrow to bar"
-  ],
-  [
-    "\\leftwhitearrow",
-    "leftwards white arrow"
-  ],
-  [
-    "\\upwhitearrow",
-    "upwards white arrow"
-  ],
-  [
-    "\\rightwhitearrow",
-    "rightwards white arrow"
-  ],
-  [
-    "\\downwhitearrow",
-    "downwards white arrow"
-  ],
-  [
-    "\\whitearrowupfrombar",
-    "upwards white arrow from bar"
-  ],
-  [
-    "\\circleonrightarrow",
-    "right arrow with small circle"
-  ],
-  [
-    "\\downuparrows",
-    "downwards arrow leftwards of upwards arrow"
-  ],
-  [
-    "\\rightthreearrows",
-    "three rightwards arrows"
-  ],
-  [
-    "\\nvleftarrow",
-    "leftwards arrow with vertical stroke"
-  ],
-  [
-    "\\nvrightarrow",
-    "rightwards arrow with vertical stroke"
-  ],
-  [
-    "\\nvleftrightarrow",
-    "left right arrow with vertical stroke"
-  ],
-  [
-    "\\nVleftarrow",
-    "leftwards arrow with double vertical stroke"
-  ],
-  [
-    "\\nVrightarrow",
-    "rightwards arrow with double vertical stroke"
-  ],
-  [
-    "\\nVleftrightarrow",
-    "left right arrow with double vertical stroke"
-  ],
-  [
-    "\\leftarrowtriangle",
-    "leftwards open-headed arrow"
-  ],
-  [
-    "\\rightarrowtriangle",
-    "rightwards open-headed arrow"
-  ],
-  [
-    "\\leftrightarrowtriangle",
-    "left right open-headed arrow"
-  ],
-  [
-    "\\forall",
-    "for all"
-  ],
-  [
-    "\\complement",
-    "complement sign"
-  ],
-  [
-    "\\partial",
-    "partial differential"
-  ],
-  [
-    "\\exists",
-    "at least one exists"
-  ],
-  [
-    "\\nexists",
-    "negated exists"
-  ],
-  [
-    "\\varnothing",
-    "circle, slash"
-  ],
-  [
-    "\\increment",
-    "laplacian (delta; nabla\\string^2)"
-  ],
-  [
-    "\\nabla",
-    "nabla, del, hamilton operator"
-  ],
-  [
-    "\\in",
-    "set membership, variant"
-  ],
-  [
-    "\\notin",
-    "negated set membership"
-  ],
-  [
-    "\\smallin",
-    "set membership (small set membership)"
-  ],
-  [
-    "\\ni",
-    "contains, variant"
-  ],
-  [
-    "\\nni",
-    "negated contains, variant"
-  ],
-  [
-    "\\smallni",
-    "/ni /owns r: contains (small contains as member)"
-  ],
-  [
-    "\\QED",
-    "end of proof"
-  ],
-  [
-    "\\prod",
-    "product operator"
-  ],
-  [
-    "\\coprod",
-    "coproduct operator"
-  ],
-  [
-    "\\sum",
-    "summation operator"
-  ],
-  [
-    "\\minus",
-    "minus sign"
-  ],
-  [
-    "\\mp",
-    "minus-or-plus sign"
-  ],
-  [
-    "\\dotplus",
-    "plus sign, dot above"
-  ],
-  [
-    "\\divslash",
-    "division slash"
-  ],
-  [
-    "\\smallsetminus",
-    "small set minus (cf. reverse solidus)"
-  ],
-  [
-    "\\ast",
-    "centered asterisk"
-  ],
-  [
-    "\\vysmwhtcircle",
-    "composite function (small circle)"
-  ],
-  [
-    "\\vysmblkcircle",
-    "bullet operator"
-  ],
-  [
-    "\\sqrt",
-    "radical"
-  ],
-  [
-    "\\surd",
-    "radical"
-  ],
-  [
-    "\\cuberoot",
-    "cube root"
-  ],
-  [
-    "\\fourthroot",
-    "fourth root"
-  ],
-  [
-    "\\propto",
-    "is proportional to"
-  ],
-  [
-    "\\infty",
-    "infinity"
-  ],
-  [
-    "\\rightangle",
-    "right (90 degree) angle"
-  ],
-  [
-    "\\angle",
-    "angle"
-  ],
-  [
-    "\\measuredangle",
-    "angle-measured"
-  ],
-  [
-    "\\sphericalangle",
-    "angle-spherical"
-  ],
-  [
-    "\\mid",
-    "/mid r:"
-  ],
-  [
-    "\\nmid",
-    "negated mid"
-  ],
-  [
-    "\\parallel",
-    "parallel"
-  ],
-  [
-    "\\nparallel",
-    "not parallel"
-  ],
-  [
-    "\\wedge",
-    "/wedge /land b: logical and"
-  ],
-  [
-    "\\vee",
-    "/vee /lor b: logical or"
-  ],
-  [
-    "\\cap",
-    "intersection"
-  ],
-  [
-    "\\cup",
-    "union or logical sum"
-  ],
-  [
-    "\\int",
-    "integral operator"
-  ],
-  [
-    "\\iint",
-    "double integral operator"
-  ],
-  [
-    "\\iiint",
-    "triple integral operator"
-  ],
-  [
-    "\\oint",
-    "contour integral operator"
-  ],
-  [
-    "\\oiint",
-    "double contour integral operator"
-  ],
-  [
-    "\\oiiint",
-    "triple contour integral operator"
-  ],
-  [
-    "\\intclockwise",
-    "clockwise integral"
-  ],
-  [
-    "\\varointclockwise",
-    "contour integral, clockwise"
-  ],
-  [
-    "\\ointctrclockwise",
-    "contour integral, anticlockwise"
-  ],
-  [
-    "\\therefore",
-    "therefore"
-  ],
-  [
-    "\\because",
-    "because"
-  ],
-  [
-    "\\mathratio",
-    "ratio"
-  ],
-  [
-    "\\Colon",
-    "two colons"
-  ],
-  [
-    "\\dotminus",
-    "minus sign, dot above"
-  ],
-  [
-    "\\dashcolon",
-    "excess (-:)"
-  ],
-  [
-    "\\dotsminusdots",
-    "minus with four dots, geometric properties"
-  ],
-  [
-    "\\kernelcontraction",
-    "homothetic"
-  ],
-  [
-    "\\sim",
-    "similar"
-  ],
-  [
-    "\\backsim",
-    "reverse similar"
-  ],
-  [
-    "\\invlazys",
-    "most positive [inverted lazy s]"
-  ],
-  [
-    "\\sinewave",
-    "sine wave"
-  ],
-  [
-    "\\wr",
-    "wreath product"
-  ],
-  [
-    "\\nsim",
-    "not similar"
-  ],
-  [
-    "\\eqsim",
-    "equals, similar"
-  ],
-  [
-    "\\simeq",
-    "similar, equals"
-  ],
-  [
-    "\\nsime",
-    "not similar, equals"
-  ],
-  [
-    "\\sime",
-    "similar, equals (alias)"
-  ],
-  [
-    "\\nsimeq",
-    "not similar, equals (alias)"
-  ],
-  [
-    "\\cong",
-    "congruent with"
-  ],
-  [
-    "\\simneqq",
-    "similar, not equals [vert only for 9573 entity]"
-  ],
-  [
-    "\\ncong",
-    "not congruent with"
-  ],
-  [
-    "\\approx",
-    "approximate"
-  ],
-  [
-    "\\napprox",
-    "not approximate"
-  ],
-  [
-    "\\approxeq",
-    "approximate, equals"
-  ],
-  [
-    "\\approxident",
-    "approximately identical to"
-  ],
-  [
-    "\\backcong",
-    "all equal to"
-  ],
-  [
-    "\\asymp",
-    "asymptotically equal to"
-  ],
-  [
-    "\\Bumpeq",
-    "bumpy equals"
-  ],
-  [
-    "\\bumpeq",
-    "bumpy equals, equals"
-  ],
-  [
-    "\\doteq",
-    "equals, single dot above"
-  ],
-  [
-    "\\Doteq",
-    "/doteqdot /doteq r: equals, even dots"
-  ],
-  [
-    "\\fallingdotseq",
-    "equals, falling dots"
-  ],
-  [
-    "\\risingdotseq",
-    "equals, rising dots"
-  ],
-  [
-    "\\coloneq",
-    "colon, equals"
-  ],
-  [
-    "\\eqcolon",
-    "equals, colon"
-  ],
-  [
-    "\\eqcirc",
-    "circle on equals sign"
-  ],
-  [
-    "\\circeq",
-    "circle, equals"
-  ],
-  [
-    "\\arceq",
-    "arc, equals; corresponds to"
-  ],
-  [
-    "\\wedgeq",
-    "corresponds to (wedge, equals)"
-  ],
-  [
-    "\\veeeq",
-    "logical or, equals"
-  ],
-  [
-    "\\stareq",
-    "star equals"
-  ],
-  [
-    "\\triangleq",
-    "triangle, equals"
-  ],
-  [
-    "\\eqdef",
-    "equals by definition"
-  ],
-  [
-    "\\measeq",
-    "measured by (m over equals)"
-  ],
-  [
-    "\\questeq",
-    "equal with questionmark"
-  ],
-  [
-    "\\ne",
-    "/ne /neq r: not equal"
-  ],
-  [
-    "\\equiv",
-    "identical with"
-  ],
-  [
-    "\\nequiv",
-    "not identical with"
-  ],
-  [
-    "\\Equiv",
-    "strict equivalence (4 lines)"
-  ],
-  [
-    "\\leq",
-    "/leq /le r: less-than-or-equal"
-  ],
-  [
-    "\\geq",
-    "/geq /ge r: greater-than-or-equal"
-  ],
-  [
-    "\\leqq",
-    "less, double equals"
-  ],
-  [
-    "\\geqq",
-    "greater, double equals"
-  ],
-  [
-    "\\lneqq",
-    "less, not double equals"
-  ],
-  [
-    "\\gneqq",
-    "greater, not double equals"
-  ],
-  [
-    "\\ll",
-    "much less than, type 2"
-  ],
-  [
-    "\\gg",
-    "much greater than, type 2"
-  ],
-  [
-    "\\between",
-    "between"
-  ],
-  [
-    "\\nasymp",
-    "not asymptotically equal to"
-  ],
-  [
-    "\\nless",
-    "not less-than"
-  ],
-  [
-    "\\ngtr",
-    "not greater-than"
-  ],
-  [
-    "\\nleq",
-    "not less-than-or-equal"
-  ],
-  [
-    "\\ngeq",
-    "not greater-than-or-equal"
-  ],
-  [
-    "\\lesssim",
-    "less, similar"
-  ],
-  [
-    "\\gtrsim",
-    "greater, similar"
-  ],
-  [
-    "\\nlesssim",
-    "not less, similar"
-  ],
-  [
-    "\\ngtrsim",
-    "not greater, similar"
-  ],
-  [
-    "\\lessgtr",
-    "less, greater"
-  ],
-  [
-    "\\gtrless",
-    "greater, less"
-  ],
-  [
-    "\\nlessgtr",
-    "not less, greater"
-  ],
-  [
-    "\\ngtrless",
-    "not greater, less"
-  ],
-  [
-    "\\prec",
-    "precedes"
-  ],
-  [
-    "\\succ",
-    "succeeds"
-  ],
-  [
-    "\\preccurlyeq",
-    "precedes, curly equals"
-  ],
-  [
-    "\\succcurlyeq",
-    "succeeds, curly equals"
-  ],
-  [
-    "\\precsim",
-    "precedes, similar"
-  ],
-  [
-    "\\succsim",
-    "succeeds, similar"
-  ],
-  [
-    "\\nprec",
-    "not precedes"
-  ],
-  [
-    "\\nsucc",
-    "not succeeds"
-  ],
-  [
-    "\\subset",
-    "subset or is implied by"
-  ],
-  [
-    "\\supset",
-    "superset or implies"
-  ],
-  [
-    "\\nsubset",
-    "not subset, variant [slash negation]"
-  ],
-  [
-    "\\nsupset",
-    "not superset, variant [slash negation]"
-  ],
-  [
-    "\\subseteq",
-    "subset, equals"
-  ],
-  [
-    "\\supseteq",
-    "superset, equals"
-  ],
-  [
-    "\\nsubseteq",
-    "not subset, equals"
-  ],
-  [
-    "\\nsupseteq",
-    "not superset, equals"
-  ],
-  [
-    "\\subsetneq",
-    "subset, not equals"
-  ],
-  [
-    "\\supsetneq",
-    "superset, not equals"
-  ],
-  [
-    "\\cupleftarrow",
-    "multiset"
-  ],
-  [
-    "\\cupdot",
-    "union, with dot"
-  ],
-  [
-    "\\uplus",
-    "plus sign in union"
-  ],
-  [
-    "\\sqsubset",
-    "square subset"
-  ],
-  [
-    "\\sqsupset",
-    "square superset"
-  ],
-  [
-    "\\sqsubseteq",
-    "square subset, equals"
-  ],
-  [
-    "\\sqsupseteq",
-    "square superset, equals"
-  ],
-  [
-    "\\sqcap",
-    "square intersection"
-  ],
-  [
-    "\\sqcup",
-    "square union"
-  ],
-  [
-    "\\oplus",
-    "plus sign in circle"
-  ],
-  [
-    "\\ominus",
-    "minus sign in circle"
-  ],
-  [
-    "\\otimes",
-    "multiply sign in circle"
-  ],
-  [
-    "\\oslash",
-    "solidus in circle"
-  ],
-  [
-    "\\odot",
-    "middle dot in circle"
-  ],
-  [
-    "\\circledcirc",
-    "small circle in circle"
-  ],
-  [
-    "\\circledast",
-    "asterisk in circle"
-  ],
-  [
-    "\\circledequal",
-    "equal in circle"
-  ],
-  [
-    "\\circleddash",
-    "hyphen in circle"
-  ],
-  [
-    "\\boxplus",
-    "plus sign in box"
-  ],
-  [
-    "\\boxminus",
-    "minus sign in box"
-  ],
-  [
-    "\\boxtimes",
-    "multiply sign in box"
-  ],
-  [
-    "\\boxdot",
-    "/dotsquare /boxdot b: small dot in box"
-  ],
-  [
-    "\\vdash",
-    "vertical, dash"
-  ],
-  [
-    "\\dashv",
-    "dash, vertical"
-  ],
-  [
-    "\\top",
-    "top"
-  ],
-  [
-    "\\bot",
-    "bottom"
-  ],
-  [
-    "\\assert",
-    "assertion (vertical, short dash)"
-  ],
-  [
-    "\\models",
-    "models (vertical, short double dash)"
-  ],
-  [
-    "\\vDash",
-    "vertical, double dash"
-  ],
-  [
-    "\\Vdash",
-    "double vertical, dash"
-  ],
-  [
-    "\\Vvdash",
-    "triple vertical, dash"
-  ],
-  [
-    "\\VDash",
-    "double vert, double dash"
-  ],
-  [
-    "\\nvdash",
-    "not vertical, dash"
-  ],
-  [
-    "\\nvDash",
-    "not vertical, double dash"
-  ],
-  [
-    "\\nVdash",
-    "not double vertical, dash"
-  ],
-  [
-    "\\nVDash",
-    "not double vert, double dash"
-  ],
-  [
-    "\\prurel",
-    "element precedes under relation"
-  ],
-  [
-    "\\scurel",
-    "succeeds under relation"
-  ],
-  [
-    "\\vartriangleleft",
-    "left triangle, open, variant"
-  ],
-  [
-    "\\vartriangleright",
-    "right triangle, open, variant"
-  ],
-  [
-    "\\trianglelefteq",
-    "left triangle, equals"
-  ],
-  [
-    "\\trianglerighteq",
-    "right triangle, equals"
-  ],
-  [
-    "\\origof",
-    "original of"
-  ],
-  [
-    "\\imageof",
-    "image of"
-  ],
-  [
-    "\\multimap",
-    "/multimap a:"
-  ],
-  [
-    "\\hermitmatrix",
-    "hermitian conjugate matrix"
-  ],
-  [
-    "\\intercal",
-    "intercal"
-  ],
-  [
-    "\\veebar",
-    "logical or, bar below (large vee); exclusive disjunction"
-  ],
-  [
-    "\\barwedge",
-    "bar, wedge (large wedge)"
-  ],
-  [
-    "\\barvee",
-    "bar, vee (large vee)"
-  ],
-  [
-    "\\measuredrightangle",
-    "right angle-measured [with arc]"
-  ],
-  [
-    "\\varlrtriangle",
-    "right triangle"
-  ],
-  [
-    "\\bigwedge",
-    "logical and operator"
-  ],
-  [
-    "\\bigvee",
-    "logical or operator"
-  ],
-  [
-    "\\bigcap",
-    "intersection operator"
-  ],
-  [
-    "\\bigcup",
-    "union operator"
-  ],
-  [
-    "\\smwhtdiamond",
-    "white diamond"
-  ],
-  [
-    "\\cdot",
-    "small middle dot"
-  ],
-  [
-    "\\star",
-    "small star, filled, low"
-  ],
-  [
-    "\\divideontimes",
-    "division on times"
-  ],
-  [
-    "\\bowtie",
-    "bowtie"
-  ],
-  [
-    "\\ltimes",
-    "times sign, left closed"
-  ],
-  [
-    "\\rtimes",
-    "times sign, right closed"
-  ],
-  [
-    "\\leftthreetimes",
-    "left semidirect product"
-  ],
-  [
-    "\\rightthreetimes",
-    "right semidirect product"
-  ],
-  [
-    "\\backsimeq",
-    "reverse similar, equals"
-  ],
-  [
-    "\\curlyvee",
-    "curly logical or"
-  ],
-  [
-    "\\curlywedge",
-    "curly logical and"
-  ],
-  [
-    "\\Subset",
-    "double subset"
-  ],
-  [
-    "\\Supset",
-    "double superset"
-  ],
-  [
-    "\\Cap",
-    "/cap /doublecap b: double intersection"
-  ],
-  [
-    "\\Cup",
-    "/cup /doublecup b: double union"
-  ],
-  [
-    "\\pitchfork",
-    "pitchfork"
-  ],
-  [
-    "\\equalparallel",
-    "parallel, equal; equal or parallel"
-  ],
-  [
-    "\\lessdot",
-    "less than, with dot"
-  ],
-  [
-    "\\gtrdot",
-    "greater than, with dot"
-  ],
-  [
-    "\\lll",
-    "/ll /lll /llless r: triple less-than"
-  ],
-  [
-    "\\ggg",
-    "/ggg /gg /gggtr r: triple greater-than"
-  ],
-  [
-    "\\lesseqgtr",
-    "less, equals, greater"
-  ],
-  [
-    "\\gtreqless",
-    "greater, equals, less"
-  ],
-  [
-    "\\eqless",
-    "equal-or-less"
-  ],
-  [
-    "\\eqgtr",
-    "equal-or-greater"
-  ],
-  [
-    "\\curlyeqprec",
-    "curly equals, precedes"
-  ],
-  [
-    "\\curlyeqsucc",
-    "curly equals, succeeds"
-  ],
-  [
-    "\\npreccurlyeq",
-    "not precedes, curly equals"
-  ],
-  [
-    "\\nsucccurlyeq",
-    "not succeeds, curly equals"
-  ],
-  [
-    "\\nsqsubseteq",
-    "not, square subset, equals"
-  ],
-  [
-    "\\nsqsupseteq",
-    "not, square superset, equals"
-  ],
-  [
-    "\\sqsubsetneq",
-    "square subset, not equals"
-  ],
-  [
-    "\\sqsupsetneq",
-    "square superset, not equals"
-  ],
-  [
-    "\\lnsim",
-    "less, not similar"
-  ],
-  [
-    "\\gnsim",
-    "greater, not similar"
-  ],
-  [
-    "\\precnsim",
-    "precedes, not similar"
-  ],
-  [
-    "\\succnsim",
-    "succeeds, not similar"
-  ],
-  [
-    "\\nvartriangleleft",
-    "not left triangle"
-  ],
-  [
-    "\\nvartriangleright",
-    "not right triangle"
-  ],
-  [
-    "\\ntrianglelefteq",
-    "not left triangle, equals"
-  ],
-  [
-    "\\ntrianglerighteq",
-    "not right triangle, equals"
-  ],
-  [
-    "\\vdots",
-    "vertical ellipsis"
-  ],
-  [
-    "\\unicodecdots",
-    "three dots, centered"
-  ],
-  [
-    "\\adots",
-    "three dots, ascending"
-  ],
-  [
-    "\\ddots",
-    "three dots, descending"
-  ],
-  [
-    "\\disin",
-    "element of with long horizontal stroke"
-  ],
-  [
-    "\\varisins",
-    "element of with vertical bar at end of horizontal stroke"
-  ],
-  [
-    "\\isins",
-    "small element of with vertical bar at end of horizontal stroke"
-  ],
-  [
-    "\\isindot",
-    "element of with dot above"
-  ],
-  [
-    "\\varisinobar",
-    "element of with overbar"
-  ],
-  [
-    "\\isinobar",
-    "small element of with overbar"
-  ],
-  [
-    "\\isinvb",
-    "element of with underbar"
-  ],
-  [
-    "\\isinE",
-    "element of with two horizontal strokes"
-  ],
-  [
-    "\\nisd",
-    "contains with long horizontal stroke"
-  ],
-  [
-    "\\varnis",
-    "contains with vertical bar at end of horizontal stroke"
-  ],
-  [
-    "\\nis",
-    "small contains with vertical bar at end of horizontal stroke"
-  ],
-  [
-    "\\varniobar",
-    "contains with overbar"
-  ],
-  [
-    "\\niobar",
-    "small contains with overbar"
-  ],
-  [
-    "\\bagmember",
-    "z notation bag membership"
-  ],
-  [
-    "\\diameter",
-    "diameter sign"
-  ],
-  [
-    "\\house",
-    "house"
-  ],
-  [
-    "\\varbarwedge",
-    "/barwedge b: logical and, bar above [projective (bar over small wedge)]"
-  ],
-  [
-    "\\vardoublebarwedge",
-    "/doublebarwedge b: logical and, double bar above [perspective (double bar over small wedge)]"
-  ],
-  [
-    "\\lceil",
-    "left ceiling"
-  ],
-  [
-    "\\rceil",
-    "right ceiling"
-  ],
-  [
-    "\\lfloor",
-    "left floor"
-  ],
-  [
-    "\\rfloor",
-    "right floor"
-  ],
-  [
-    "\\invnot",
-    "reverse not"
-  ],
-  [
-    "\\sqlozenge",
-    "square lozenge"
-  ],
-  [
-    "\\profline",
-    "profile of a line"
-  ],
-  [
-    "\\profsurf",
-    "profile of a surface"
-  ],
-  [
-    "\\viewdata",
-    "viewdata square"
-  ],
-  [
-    "\\turnednot",
-    "turned not sign"
-  ],
-  [
-    "\\ulcorner",
-    "upper left corner"
-  ],
-  [
-    "\\urcorner",
-    "upper right corner"
-  ],
-  [
-    "\\llcorner",
-    "lower left corner"
-  ],
-  [
-    "\\lrcorner",
-    "lower right corner"
-  ],
-  [
-    "\\inttop",
-    "top half integral"
-  ],
-  [
-    "\\intbottom",
-    "bottom half integral"
-  ],
-  [
-    "\\frown",
-    "down curve"
-  ],
-  [
-    "\\smile",
-    "up curve"
-  ],
-  [
-    "\\varhexagonlrbonds",
-    "six carbon ring, corner down, double bonds lower right etc"
-  ],
-  [
-    "\\conictaper",
-    "conical taper "
-  ],
-  [
-    "\\topbot",
-    "top and bottom"
-  ],
-  [
-    "\\obar",
-    "circle with vertical bar"
-  ],
-  [
-    "\\APLnotslash",
-    "solidus, bar through (apl functional symbol slash bar)"
-  ],
-  [
-    "\\APLnotbackslash",
-    "apl functional symbol backslash bar"
-  ],
-  [
-    "\\APLboxupcaret",
-    "boxed up caret"
-  ],
-  [
-    "\\APLboxquestion",
-    "boxed question mark"
-  ],
-  [
-    "\\rangledownzigzagarrow",
-    "right angle with downwards zigzag arrow"
-  ],
-  [
-    "\\hexagon",
-    "horizontal benzene ring [hexagon flat open]"
-  ],
-  [
-    "\\lparenuend",
-    "left parenthesis upper hook"
-  ],
-  [
-    "\\lparenextender",
-    "left parenthesis extension"
-  ],
-  [
-    "\\lparenlend",
-    "left parenthesis lower hook"
-  ],
-  [
-    "\\rparenuend",
-    "right parenthesis upper hook"
-  ],
-  [
-    "\\rparenextender",
-    "right parenthesis extension"
-  ],
-  [
-    "\\rparenlend",
-    "right parenthesis lower hook"
-  ],
-  [
-    "\\lbrackuend",
-    "left square bracket upper corner"
-  ],
-  [
-    "\\lbrackextender",
-    "left square bracket extension"
-  ],
-  [
-    "\\lbracklend",
-    "left square bracket lower corner"
-  ],
-  [
-    "\\rbrackuend",
-    "right square bracket upper corner"
-  ],
-  [
-    "\\rbrackextender",
-    "right square bracket extension"
-  ],
-  [
-    "\\rbracklend",
-    "right square bracket lower corner"
-  ],
-  [
-    "\\lbraceuend",
-    "left curly bracket upper hook"
-  ],
-  [
-    "\\lbracemid",
-    "left curly bracket middle piece"
-  ],
-  [
-    "\\lbracelend",
-    "left curly bracket lower hook"
-  ],
-  [
-    "\\vbraceextender",
-    "curly bracket extension"
-  ],
-  [
-    "\\rbraceuend",
-    "right curly bracket upper hook"
-  ],
-  [
-    "\\rbracemid",
-    "right curly bracket middle piece"
-  ],
-  [
-    "\\rbracelend",
-    "right curly bracket lower hook"
-  ],
-  [
-    "\\intextender",
-    "integral extension"
-  ],
-  [
-    "\\harrowextender",
-    "horizontal line extension (used to extend arrows)"
-  ],
-  [
-    "\\lmoustache",
-    "upper left or lower right curly bracket section"
-  ],
-  [
-    "\\rmoustache",
-    "upper right or lower left curly bracket section"
-  ],
-  [
-    "\\sumtop",
-    "summation top"
-  ],
-  [
-    "\\sumbottom",
-    "summation bottom"
-  ],
-  [
-    "\\overbracket",
-    "top square bracket"
-  ],
-  [
-    "\\underbracket",
-    "bottom square bracket"
-  ],
-  [
-    "\\bbrktbrk",
-    "bottom square bracket over top square bracket"
-  ],
-  [
-    "\\sqrtbottom",
-    "radical symbol bottom"
-  ],
-  [
-    "\\lvboxline",
-    "left vertical box line"
-  ],
-  [
-    "\\rvboxline",
-    "right vertical box line"
-  ],
-  [
-    "\\varcarriagereturn",
-    "return symbol"
-  ],
-  [
-    "\\overparen",
-    "top parenthesis (mathematical use)"
-  ],
-  [
-    "\\underparen",
-    "bottom parenthesis (mathematical use)"
-  ],
-  [
-    "\\overbrace",
-    "top curly bracket (mathematical use)"
-  ],
-  [
-    "\\underbrace",
-    "bottom curly bracket (mathematical use)"
-  ],
-  [
-    "\\obrbrak",
-    "top tortoise shell bracket (mathematical use)"
-  ],
-  [
-    "\\ubrbrak",
-    "bottom tortoise shell bracket (mathematical use)"
-  ],
-  [
-    "\\trapezium",
-    "white trapezium"
-  ],
-  [
-    "\\benzenr",
-    "benzene ring with circle"
-  ],
-  [
-    "\\strns",
-    "straightness"
-  ],
-  [
-    "\\fltns",
-    "flatness"
-  ],
-  [
-    "\\accurrent",
-    "ac current"
-  ],
-  [
-    "\\elinters",
-    "electrical intersection"
-  ],
-  [
-    "\\blanksymbol",
-    "blank symbol"
-  ],
-  [
-    "\\mathvisiblespace",
-    "open box"
-  ],
-  [
-    "\\bdtriplevdash",
-    "doubly broken vert"
-  ],
-  [
-    "\\blockuphalf",
-    "upper half block"
-  ],
-  [
-    "\\blocklowhalf",
-    "lower half block"
-  ],
-  [
-    "\\blockfull",
-    "full block"
-  ],
-  [
-    "\\blocklefthalf",
-    "left half block"
-  ],
-  [
-    "\\blockrighthalf",
-    "right half block"
-  ],
-  [
-    "\\blockqtrshaded",
-    "25\\% shaded block"
-  ],
-  [
-    "\\blockhalfshaded",
-    "50\\% shaded block"
-  ],
-  [
-    "\\blockthreeqtrshaded",
-    "75\\% shaded block"
-  ],
-  [
-    "\\mdlgblksquare",
-    "square, filled"
-  ],
-  [
-    "\\mdlgwhtsquare",
-    "square, open"
-  ],
-  [
-    "\\squoval",
-    "white square with rounded corners"
-  ],
-  [
-    "\\blackinwhitesquare",
-    "white square containing black small square"
-  ],
-  [
-    "\\squarehfill",
-    "square, horizontal rule filled"
-  ],
-  [
-    "\\squarevfill",
-    "square, vertical rule filled"
-  ],
-  [
-    "\\squarehvfill",
-    "square with orthogonal crosshatch fill"
-  ],
-  [
-    "\\squarenwsefill",
-    "square, nw-to-se rule filled"
-  ],
-  [
-    "\\squareneswfill",
-    "square, ne-to-sw rule filled"
-  ],
-  [
-    "\\squarecrossfill",
-    "square with diagonal crosshatch fill"
-  ],
-  [
-    "\\smblksquare",
-    "/blacksquare - sq bullet, filled"
-  ],
-  [
-    "\\smwhtsquare",
-    "white small square"
-  ],
-  [
-    "\\hrectangleblack",
-    "black rectangle"
-  ],
-  [
-    "\\hrectangle",
-    "horizontal rectangle, open"
-  ],
-  [
-    "\\vrectangleblack",
-    "black vertical rectangle"
-  ],
-  [
-    "\\vrectangle",
-    "rectangle, white (vertical)"
-  ],
-  [
-    "\\parallelogramblack",
-    "black parallelogram"
-  ],
-  [
-    "\\parallelogram",
-    "parallelogram, open"
-  ],
-  [
-    "\\bigblacktriangleup",
-    "black up-pointing triangle"
-  ],
-  [
-    "\\bigtriangleup",
-    "big up triangle, open"
-  ],
-  [
-    "\\blacktriangle",
-    "up triangle, filled"
-  ],
-  [
-    "\\vartriangle",
-    "/triangle - up triangle, open"
-  ],
-  [
-    "\\blacktriangleright",
-    "(large) right triangle, filled"
-  ],
-  [
-    "\\triangleright",
-    "(large) right triangle, open; z notation range restriction"
-  ],
-  [
-    "\\smallblacktriangleright",
-    "right triangle, filled"
-  ],
-  [
-    "\\smalltriangleright",
-    "right triangle, open"
-  ],
-  [
-    "\\blackpointerright",
-    "black right-pointing pointer"
-  ],
-  [
-    "\\whitepointerright",
-    "white right-pointing pointer"
-  ],
-  [
-    "\\bigblacktriangledown",
-    "big down triangle, filled"
-  ],
-  [
-    "\\bigtriangledown",
-    "big down triangle, open"
-  ],
-  [
-    "\\blacktriangledown",
-    "down triangle, filled"
-  ],
-  [
-    "\\triangledown",
-    "down triangle, open"
-  ],
-  [
-    "\\blacktriangleleft",
-    "(large) left triangle, filled"
-  ],
-  [
-    "\\triangleleft",
-    "(large) left triangle, open; z notation domain restriction"
-  ],
-  [
-    "\\smallblacktriangleleft",
-    "left triangle, filled"
-  ],
-  [
-    "\\smalltriangleleft",
-    "left triangle, open"
-  ],
-  [
-    "\\blackpointerleft",
-    "black left-pointing pointer"
-  ],
-  [
-    "\\whitepointerleft",
-    "white left-pointing pointer"
-  ],
-  [
-    "\\mdlgblkdiamond",
-    "black diamond"
-  ],
-  [
-    "\\mdlgwhtdiamond",
-    "white diamond; diamond, open"
-  ],
-  [
-    "\\blackinwhitediamond",
-    "white diamond containing black small diamond"
-  ],
-  [
-    "\\fisheye",
-    "fisheye"
-  ],
-  [
-    "\\mdlgwhtlozenge",
-    "lozenge or total mark"
-  ],
-  [
-    "\\mdlgwhtcircle",
-    "medium large circle"
-  ],
-  [
-    "\\dottedcircle",
-    "dotted circle"
-  ],
-  [
-    "\\circlevertfill",
-    "circle with vertical fill"
-  ],
-  [
-    "\\bullseye",
-    "bullseye"
-  ],
-  [
-    "\\mdlgblkcircle",
-    "circle, filled"
-  ],
-  [
-    "\\circlelefthalfblack",
-    "circle, filled left half [harvey ball]"
-  ],
-  [
-    "\\circlerighthalfblack",
-    "circle, filled right half"
-  ],
-  [
-    "\\circlebottomhalfblack",
-    "circle, filled bottom half"
-  ],
-  [
-    "\\circletophalfblack",
-    "circle, filled top half"
-  ],
-  [
-    "\\circleurquadblack",
-    "circle with upper right quadrant black"
-  ],
-  [
-    "\\blackcircleulquadwhite",
-    "circle with all but upper left quadrant black"
-  ],
-  [
-    "\\blacklefthalfcircle",
-    "left half black circle"
-  ],
-  [
-    "\\blackrighthalfcircle",
-    "right half black circle"
-  ],
-  [
-    "\\inversebullet",
-    "inverse bullet "
-  ],
-  [
-    "\\inversewhitecircle",
-    "inverse white circle"
-  ],
-  [
-    "\\invwhiteupperhalfcircle",
-    "upper half inverse white circle"
-  ],
-  [
-    "\\invwhitelowerhalfcircle",
-    "lower half inverse white circle"
-  ],
-  [
-    "\\ularc",
-    "upper left quadrant circular arc"
-  ],
-  [
-    "\\urarc",
-    "upper right quadrant circular arc"
-  ],
-  [
-    "\\lrarc",
-    "lower right quadrant circular arc"
-  ],
-  [
-    "\\llarc",
-    "lower left quadrant circular arc"
-  ],
-  [
-    "\\topsemicircle",
-    "upper half circle"
-  ],
-  [
-    "\\botsemicircle",
-    "lower half circle"
-  ],
-  [
-    "\\lrblacktriangle",
-    "lower right triangle, filled"
-  ],
-  [
-    "\\llblacktriangle",
-    "lower left triangle, filled"
-  ],
-  [
-    "\\ulblacktriangle",
-    "upper left triangle, filled"
-  ],
-  [
-    "\\urblacktriangle",
-    "upper right triangle, filled"
-  ],
-  [
-    "\\smwhtcircle",
-    "white bullet"
-  ],
-  [
-    "\\squareleftblack",
-    "square, filled left half"
-  ],
-  [
-    "\\squarerightblack",
-    "square, filled right half"
-  ],
-  [
-    "\\squareulblack",
-    "square, filled top left corner"
-  ],
-  [
-    "\\squarelrblack",
-    "square, filled bottom right corner"
-  ],
-  [
-    "\\boxbar",
-    "vertical bar in box"
-  ],
-  [
-    "\\trianglecdot",
-    "triangle with centered dot"
-  ],
-  [
-    "\\triangleleftblack",
-    "up-pointing triangle with left half black"
-  ],
-  [
-    "\\trianglerightblack",
-    "up-pointing triangle with right half black"
-  ],
-  [
-    "\\lgwhtcircle",
-    "large circle"
-  ],
-  [
-    "\\squareulquad",
-    "white square with upper left quadrant"
-  ],
-  [
-    "\\squarellquad",
-    "white square with lower left quadrant"
-  ],
-  [
-    "\\squarelrquad",
-    "white square with lower right quadrant"
-  ],
-  [
-    "\\squareurquad",
-    "white square with upper right quadrant"
-  ],
-  [
-    "\\circleulquad",
-    "white circle with upper left quadrant"
-  ],
-  [
-    "\\circlellquad",
-    "white circle with lower left quadrant"
-  ],
-  [
-    "\\circlelrquad",
-    "white circle with lower right quadrant"
-  ],
-  [
-    "\\circleurquad",
-    "white circle with upper right quadrant"
-  ],
-  [
-    "\\ultriangle",
-    "upper left triangle"
-  ],
-  [
-    "\\urtriangle",
-    "upper right triangle"
-  ],
-  [
-    "\\lltriangle",
-    "lower left triangle"
-  ],
-  [
-    "\\mdwhtsquare",
-    "white medium square"
-  ],
-  [
-    "\\mdblksquare",
-    "black medium square"
-  ],
-  [
-    "\\mdsmwhtsquare",
-    "white medium small square"
-  ],
-  [
-    "\\mdsmblksquare",
-    "black medium small square"
-  ],
-  [
-    "\\lrtriangle",
-    "lower right triangle"
-  ],
-  [
-    "\\bigstar",
-    "star, filled"
-  ],
-  [
-    "\\bigwhitestar",
-    "star, open"
-  ],
-  [
-    "\\astrosun",
-    "sun"
-  ],
-  [
-    "\\danger",
-    "dangerous bend (caution sign)"
-  ],
-  [
-    "\\blacksmiley",
-    "black smiling face"
-  ],
-  [
-    "\\sun",
-    "white sun with rays"
-  ],
-  [
-    "\\rightmoon",
-    "first quarter moon"
-  ],
-  [
-    "\\leftmoon",
-    "last quarter moon"
-  ],
-  [
-    "\\female",
-    "venus, female"
-  ],
-  [
-    "\\male",
-    "mars, male"
-  ],
-  [
-    "\\spadesuit",
-    "spades suit symbol"
-  ],
-  [
-    "\\heartsuit",
-    "heart suit symbol"
-  ],
-  [
-    "\\diamondsuit",
-    "diamond suit symbol"
-  ],
-  [
-    "\\clubsuit",
-    "club suit symbol"
-  ],
-  [
-    "\\varspadesuit",
-    "spade, white (card suit)"
-  ],
-  [
-    "\\varheartsuit",
-    "filled heart (card suit)"
-  ],
-  [
-    "\\vardiamondsuit",
-    "filled diamond (card suit)"
-  ],
-  [
-    "\\varclubsuit",
-    "club, white (card suit)"
-  ],
-  [
-    "\\quarternote",
-    "music note (sung text sign)"
-  ],
-  [
-    "\\eighthnote",
-    "eighth note"
-  ],
-  [
-    "\\twonotes",
-    "beamed eighth notes"
-  ],
-  [
-    "\\flat",
-    "musical flat"
-  ],
-  [
-    "\\natural",
-    "music natural"
-  ],
-  [
-    "\\sharp",
-    "musical sharp"
-  ],
-  [
-    "\\acidfree",
-    "permanent paper sign"
-  ],
-  [
-    "\\dicei",
-    "die face-1"
-  ],
-  [
-    "\\diceii",
-    "die face-2"
-  ],
-  [
-    "\\diceiii",
-    "die face-3"
-  ],
-  [
-    "\\diceiv",
-    "die face-4"
-  ],
-  [
-    "\\dicev",
-    "die face-5"
-  ],
-  [
-    "\\dicevi",
-    "die face-6"
-  ],
-  [
-    "\\circledrightdot",
-    "white circle with dot right"
-  ],
-  [
-    "\\circledtwodots",
-    "white circle with two dots"
-  ],
-  [
-    "\\blackcircledrightdot",
-    "black circle with white dot right"
-  ],
-  [
-    "\\blackcircledtwodots",
-    "black circle with two white dots"
-  ],
-  [
-    "\\Hermaphrodite",
-    "male and female sign"
-  ],
-  [
-    "\\mdwhtcircle",
-    "medium white circle"
-  ],
-  [
-    "\\mdblkcircle",
-    "medium black circle"
-  ],
-  [
-    "\\mdsmwhtcircle",
-    "medium small white circle"
-  ],
-  [
-    "\\neuter",
-    "neuter"
-  ],
-  [
-    "\\checkmark",
-    "tick, check mark"
-  ],
-  [
-    "\\maltese",
-    "maltese cross"
-  ],
-  [
-    "\\circledstar",
-    "circled white star"
-  ],
-  [
-    "\\varstar",
-    "six pointed black star"
-  ],
-  [
-    "\\dingasterisk",
-    "heavy teardrop-spoked asterisk"
-  ],
-  [
-    "\\lbrbrak",
-    "light left tortoise shell bracket ornament"
-  ],
-  [
-    "\\rbrbrak",
-    "light right tortoise shell bracket ornament"
-  ],
-  [
-    "\\draftingarrow",
-    "right arrow with bold head (drafting)"
-  ],
-  [
-    "\\threedangle",
-    "three dimensional angle"
-  ],
-  [
-    "\\whiteinwhitetriangle",
-    "white triangle containing small white triangle"
-  ],
-  [
-    "\\perp",
-    "perpendicular"
-  ],
-  [
-    "\\subsetcirc",
-    "open subset"
-  ],
-  [
-    "\\supsetcirc",
-    "open superset"
-  ],
-  [
-    "\\lbag",
-    "left s-shaped bag delimiter"
-  ],
-  [
-    "\\rbag",
-    "right s-shaped bag delimiter"
-  ],
-  [
-    "\\veedot",
-    "or with dot inside"
-  ],
-  [
-    "\\bsolhsub",
-    "reverse solidus preceding subset"
-  ],
-  [
-    "\\suphsol",
-    "superset preceding solidus"
-  ],
-  [
-    "\\longdivision",
-    "long division"
-  ],
-  [
-    "\\diamondcdot",
-    "white diamond with centred dot"
-  ],
-  [
-    "\\wedgedot",
-    "and with dot"
-  ],
-  [
-    "\\upin",
-    "element of opening upwards"
-  ],
-  [
-    "\\pullback",
-    "lower right corner with dot"
-  ],
-  [
-    "\\pushout",
-    "upper left corner with dot"
-  ],
-  [
-    "\\leftouterjoin",
-    "left outer join"
-  ],
-  [
-    "\\rightouterjoin",
-    "right outer join"
-  ],
-  [
-    "\\fullouterjoin",
-    "full outer join"
-  ],
-  [
-    "\\bigbot",
-    "large up tack"
-  ],
-  [
-    "\\bigtop",
-    "large down tack"
-  ],
-  [
-    "\\DashVDash",
-    "left and right double turnstile"
-  ],
-  [
-    "\\dashVdash",
-    "left and right tack"
-  ],
-  [
-    "\\multimapinv",
-    "left multimap"
-  ],
-  [
-    "\\vlongdash",
-    "long left tack"
-  ],
-  [
-    "\\longdashv",
-    "long right tack"
-  ],
-  [
-    "\\cirbot",
-    "up tack with circle above"
-  ],
-  [
-    "\\lozengeminus",
-    "lozenge divided by horizontal rule"
-  ],
-  [
-    "\\concavediamond",
-    "white concave-sided diamond"
-  ],
-  [
-    "\\concavediamondtickleft",
-    "white concave-sided diamond with leftwards tick"
-  ],
-  [
-    "\\concavediamondtickright",
-    "white concave-sided diamond with rightwards tick"
-  ],
-  [
-    "\\whitesquaretickleft",
-    "white square with leftwards tick"
-  ],
-  [
-    "\\whitesquaretickright",
-    "white square with rightwards tick"
-  ],
-  [
-    "\\lBrack",
-    "mathematical left white square bracket"
-  ],
-  [
-    "\\rBrack",
-    "mathematical right white square bracket"
-  ],
-  [
-    "\\langle",
-    "mathematical left angle bracket"
-  ],
-  [
-    "\\rangle",
-    "mathematical right angle bracket"
-  ],
-  [
-    "\\lAngle",
-    "mathematical left double angle bracket"
-  ],
-  [
-    "\\rAngle",
-    "mathematical right double angle bracket"
-  ],
-  [
-    "\\Lbrbrak",
-    "mathematical left white tortoise shell bracket"
-  ],
-  [
-    "\\Rbrbrak",
-    "mathematical right white tortoise shell bracket"
-  ],
-  [
-    "\\lgroup",
-    "mathematical left flattened parenthesis"
-  ],
-  [
-    "\\rgroup",
-    "mathematical right flattened parenthesis"
-  ],
-  [
-    "\\UUparrow",
-    "upwards quadruple arrow"
-  ],
-  [
-    "\\DDownarrow",
-    "downwards quadruple arrow"
-  ],
-  [
-    "\\acwgapcirclearrow",
-    "anticlockwise gapped circle arrow"
-  ],
-  [
-    "\\cwgapcirclearrow",
-    "clockwise gapped circle arrow"
-  ],
-  [
-    "\\rightarrowonoplus",
-    "right arrow with circled plus"
-  ],
-  [
-    "\\longleftarrow",
-    "long leftwards arrow"
-  ],
-  [
-    "\\longrightarrow",
-    "long rightwards arrow"
-  ],
-  [
-    "\\longleftrightarrow",
-    "long left right arrow"
-  ],
-  [
-    "\\Longleftarrow",
-    "long leftwards double arrow"
-  ],
-  [
-    "\\Longrightarrow",
-    "long rightwards double arrow"
-  ],
-  [
-    "\\Longleftrightarrow",
-    "long left right double arrow"
-  ],
-  [
-    "\\longmapsfrom",
-    "long leftwards arrow from bar"
-  ],
-  [
-    "\\longmapsto",
-    "long rightwards arrow from bar"
-  ],
-  [
-    "\\Longmapsfrom",
-    "long leftwards double arrow from bar"
-  ],
-  [
-    "\\Longmapsto",
-    "long rightwards double arrow from bar"
-  ],
-  [
-    "\\longrightsquigarrow",
-    "long rightwards squiggle arrow"
-  ],
-  [
-    "\\nvtwoheadrightarrow",
-    "rightwards two-headed arrow with vertical stroke"
-  ],
-  [
-    "\\nVtwoheadrightarrow",
-    "rightwards two-headed arrow with double vertical stroke"
-  ],
-  [
-    "\\nvLeftarrow",
-    "leftwards double arrow with vertical stroke"
-  ],
-  [
-    "\\nvRightarrow",
-    "rightwards double arrow with vertical stroke"
-  ],
-  [
-    "\\nvLeftrightarrow",
-    "left right double arrow with vertical stroke"
-  ],
-  [
-    "\\twoheadmapsto",
-    "rightwards two-headed arrow from bar"
-  ],
-  [
-    "\\Mapsfrom",
-    "leftwards double arrow from bar"
-  ],
-  [
-    "\\Mapsto",
-    "rightwards double arrow from bar"
-  ],
-  [
-    "\\downarrowbarred",
-    "downwards arrow with horizontal stroke"
-  ],
-  [
-    "\\uparrowbarred",
-    "upwards arrow with horizontal stroke"
-  ],
-  [
-    "\\Uuparrow",
-    "upwards triple arrow"
-  ],
-  [
-    "\\Ddownarrow",
-    "downwards triple arrow"
-  ],
-  [
-    "\\leftbkarrow",
-    "leftwards double dash arrow"
-  ],
-  [
-    "\\rightbkarrow",
-    "rightwards double dash arrow"
-  ],
-  [
-    "\\leftdbkarrow",
-    "leftwards triple dash arrow"
-  ],
-  [
-    "\\dbkarrow",
-    "rightwards triple dash arrow"
-  ],
-  [
-    "\\drbkarrow",
-    "rightwards two-headed triple dash arrow"
-  ],
-  [
-    "\\rightdotarrow",
-    "rightwards arrow with dotted stem"
-  ],
-  [
-    "\\baruparrow",
-    "upwards arrow to bar"
-  ],
-  [
-    "\\downarrowbar",
-    "downwards arrow to bar"
-  ],
-  [
-    "\\nvrightarrowtail",
-    "rightwards arrow with tail with vertical stroke"
-  ],
-  [
-    "\\nVrightarrowtail",
-    "rightwards arrow with tail with double vertical stroke"
-  ],
-  [
-    "\\twoheadrightarrowtail",
-    "rightwards two-headed arrow with tail"
-  ],
-  [
-    "\\nvtwoheadrightarrowtail",
-    "rightwards two-headed arrow with tail with vertical stroke"
-  ],
-  [
-    "\\nVtwoheadrightarrowtail",
-    "rightwards two-headed arrow with tail with double vertical stroke"
-  ],
-  [
-    "\\lefttail",
-    "leftwards arrow-tail"
-  ],
-  [
-    "\\righttail",
-    "rightwards arrow-tail"
-  ],
-  [
-    "\\leftdbltail",
-    "leftwards double arrow-tail"
-  ],
-  [
-    "\\rightdbltail",
-    "rightwards double arrow-tail"
-  ],
-  [
-    "\\diamondleftarrow",
-    "leftwards arrow to black diamond"
-  ],
-  [
-    "\\rightarrowdiamond",
-    "rightwards arrow to black diamond"
-  ],
-  [
-    "\\diamondleftarrowbar",
-    "leftwards arrow from bar to black diamond"
-  ],
-  [
-    "\\barrightarrowdiamond",
-    "rightwards arrow from bar to black diamond"
-  ],
-  [
-    "\\nwsearrow",
-    "north west and south east arrow"
-  ],
-  [
-    "\\neswarrow",
-    "north east and south west arrow"
-  ],
-  [
-    "\\hknwarrow",
-    "north west arrow with hook"
-  ],
-  [
-    "\\hknearrow",
-    "north east arrow with hook"
-  ],
-  [
-    "\\hksearrow",
-    "south east arrow with hook"
-  ],
-  [
-    "\\hkswarrow",
-    "south west arrow with hook"
-  ],
-  [
-    "\\tona",
-    "north west arrow and north east arrow"
-  ],
-  [
-    "\\toea",
-    "north east arrow and south east arrow"
-  ],
-  [
-    "\\tosa",
-    "south east arrow and south west arrow"
-  ],
-  [
-    "\\towa",
-    "south west arrow and north west arrow"
-  ],
-  [
-    "\\rdiagovfdiag",
-    "rising diagonal crossing falling diagonal"
-  ],
-  [
-    "\\fdiagovrdiag",
-    "falling diagonal crossing rising diagonal"
-  ],
-  [
-    "\\seovnearrow",
-    "south east arrow crossing north east arrow"
-  ],
-  [
-    "\\neovsearrow",
-    "north east arrow crossing south east arrow"
-  ],
-  [
-    "\\fdiagovnearrow",
-    "falling diagonal crossing north east arrow"
-  ],
-  [
-    "\\rdiagovsearrow",
-    "rising diagonal crossing south east arrow"
-  ],
-  [
-    "\\neovnwarrow",
-    "north east arrow crossing north west arrow"
-  ],
-  [
-    "\\nwovnearrow",
-    "north west arrow crossing north east arrow"
-  ],
-  [
-    "\\rightcurvedarrow",
-    "wave arrow pointing directly right"
-  ],
-  [
-    "\\uprightcurvearrow",
-    "arrow pointing rightwards then curving upwards"
-  ],
-  [
-    "\\downrightcurvedarrow",
-    "arrow pointing rightwards then curving downwards"
-  ],
-  [
-    "\\leftdowncurvedarrow",
-    "arrow pointing downwards then curving leftwards"
-  ],
-  [
-    "\\rightdowncurvedarrow",
-    "arrow pointing downwards then curving rightwards"
-  ],
-  [
-    "\\cwrightarcarrow",
-    "right-side arc clockwise arrow"
-  ],
-  [
-    "\\acwleftarcarrow",
-    "left-side arc anticlockwise arrow"
-  ],
-  [
-    "\\acwoverarcarrow",
-    "top arc anticlockwise arrow"
-  ],
-  [
-    "\\acwunderarcarrow",
-    "bottom arc anticlockwise arrow"
-  ],
-  [
-    "\\curvearrowrightminus",
-    "top arc clockwise arrow with minus"
-  ],
-  [
-    "\\curvearrowleftplus",
-    "top arc anticlockwise arrow with plus"
-  ],
-  [
-    "\\cwundercurvearrow",
-    "lower right semicircular clockwise arrow"
-  ],
-  [
-    "\\ccwundercurvearrow",
-    "lower left semicircular anticlockwise arrow"
-  ],
-  [
-    "\\acwcirclearrow",
-    "anticlockwise closed circle arrow"
-  ],
-  [
-    "\\cwcirclearrow",
-    "clockwise closed circle arrow"
-  ],
-  [
-    "\\rightarrowshortleftarrow",
-    "rightwards arrow above short leftwards arrow"
-  ],
-  [
-    "\\leftarrowshortrightarrow",
-    "leftwards arrow above short rightwards arrow"
-  ],
-  [
-    "\\shortrightarrowleftarrow",
-    "short rightwards arrow above leftwards arrow"
-  ],
-  [
-    "\\rightarrowplus",
-    "rightwards arrow with plus below"
-  ],
-  [
-    "\\leftarrowplus",
-    "leftwards arrow with plus below"
-  ],
-  [
-    "\\rightarrowx",
-    "rightwards arrow through x"
-  ],
-  [
-    "\\leftrightarrowcircle",
-    "left right arrow through small circle"
-  ],
-  [
-    "\\twoheaduparrowcircle",
-    "upwards two-headed arrow from small circle"
-  ],
-  [
-    "\\leftrightharpoonupdown",
-    "left barb up right barb down harpoon"
-  ],
-  [
-    "\\leftrightharpoondownup",
-    "left barb down right barb up harpoon"
-  ],
-  [
-    "\\updownharpoonrightleft",
-    "up barb right down barb left harpoon"
-  ],
-  [
-    "\\updownharpoonleftright",
-    "up barb left down barb right harpoon"
-  ],
-  [
-    "\\leftrightharpoonupup",
-    "left barb up right barb up harpoon"
-  ],
-  [
-    "\\updownharpoonrightright",
-    "up barb right down barb right harpoon"
-  ],
-  [
-    "\\leftrightharpoondowndown",
-    "left barb down right barb down harpoon"
-  ],
-  [
-    "\\updownharpoonleftleft",
-    "up barb left down barb left harpoon"
-  ],
-  [
-    "\\barleftharpoonup",
-    "leftwards harpoon with barb up to bar"
-  ],
-  [
-    "\\rightharpoonupbar",
-    "rightwards harpoon with barb up to bar"
-  ],
-  [
-    "\\barupharpoonright",
-    "upwards harpoon with barb right to bar"
-  ],
-  [
-    "\\downharpoonrightbar",
-    "downwards harpoon with barb right to bar"
-  ],
-  [
-    "\\barleftharpoondown",
-    "leftwards harpoon with barb down to bar"
-  ],
-  [
-    "\\rightharpoondownbar",
-    "rightwards harpoon with barb down to bar"
-  ],
-  [
-    "\\barupharpoonleft",
-    "upwards harpoon with barb left to bar"
-  ],
-  [
-    "\\downharpoonleftbar",
-    "downwards harpoon with barb left to bar"
-  ],
-  [
-    "\\leftharpoonupbar",
-    "leftwards harpoon with barb up from bar"
-  ],
-  [
-    "\\barrightharpoonup",
-    "rightwards harpoon with barb up from bar"
-  ],
-  [
-    "\\upharpoonrightbar",
-    "upwards harpoon with barb right from bar"
-  ],
-  [
-    "\\bardownharpoonright",
-    "downwards harpoon with barb right from bar"
-  ],
-  [
-    "\\leftharpoondownbar",
-    "leftwards harpoon with barb down from bar"
-  ],
-  [
-    "\\barrightharpoondown",
-    "rightwards harpoon with barb down from bar"
-  ],
-  [
-    "\\upharpoonleftbar",
-    "upwards harpoon with barb left from bar"
-  ],
-  [
-    "\\bardownharpoonleft",
-    "downwards harpoon with barb left from bar"
-  ],
-  [
-    "\\leftharpoonsupdown",
-    "leftwards harpoon with barb up above leftwards harpoon with barb down"
-  ],
-  [
-    "\\upharpoonsleftright",
-    "upwards harpoon with barb left beside upwards harpoon with barb right"
-  ],
-  [
-    "\\rightharpoonsupdown",
-    "rightwards harpoon with barb up above rightwards harpoon with barb down"
-  ],
-  [
-    "\\downharpoonsleftright",
-    "downwards harpoon with barb left beside downwards harpoon with barb right"
-  ],
-  [
-    "\\leftrightharpoonsup",
-    "leftwards harpoon with barb up above rightwards harpoon with barb up"
-  ],
-  [
-    "\\leftrightharpoonsdown",
-    "leftwards harpoon with barb down above rightwards harpoon with barb down"
-  ],
-  [
-    "\\rightleftharpoonsup",
-    "rightwards harpoon with barb up above leftwards harpoon with barb up"
-  ],
-  [
-    "\\rightleftharpoonsdown",
-    "rightwards harpoon with barb down above leftwards harpoon with barb down"
-  ],
-  [
-    "\\leftharpoonupdash",
-    "leftwards harpoon with barb up above long dash"
-  ],
-  [
-    "\\dashleftharpoondown",
-    "leftwards harpoon with barb down below long dash"
-  ],
-  [
-    "\\rightharpoonupdash",
-    "rightwards harpoon with barb up above long dash"
-  ],
-  [
-    "\\dashrightharpoondown",
-    "rightwards harpoon with barb down below long dash"
-  ],
-  [
-    "\\updownharpoonsleftright",
-    "upwards harpoon with barb left beside downwards harpoon with barb right"
-  ],
-  [
-    "\\downupharpoonsleftright",
-    "downwards harpoon with barb left beside upwards harpoon with barb right"
-  ],
-  [
-    "\\rightimply",
-    "right double arrow with rounded head"
-  ],
-  [
-    "\\equalrightarrow",
-    "equals sign above rightwards arrow"
-  ],
-  [
-    "\\similarrightarrow",
-    "tilde operator above rightwards arrow"
-  ],
-  [
-    "\\leftarrowsimilar",
-    "leftwards arrow above tilde operator"
-  ],
-  [
-    "\\rightarrowsimilar",
-    "rightwards arrow above tilde operator"
-  ],
-  [
-    "\\rightarrowapprox",
-    "rightwards arrow above almost equal to"
-  ],
-  [
-    "\\ltlarr",
-    "less-than above leftwards arrow"
-  ],
-  [
-    "\\leftarrowless",
-    "leftwards arrow through less-than"
-  ],
-  [
-    "\\gtrarr",
-    "greater-than above rightwards arrow"
-  ],
-  [
-    "\\subrarr",
-    "subset above rightwards arrow"
-  ],
-  [
-    "\\leftarrowsubset",
-    "leftwards arrow through subset"
-  ],
-  [
-    "\\suplarr",
-    "superset above leftwards arrow"
-  ],
-  [
-    "\\leftfishtail",
-    "left fish tail"
-  ],
-  [
-    "\\rightfishtail",
-    "right fish tail"
-  ],
-  [
-    "\\upfishtail",
-    "up fish tail"
-  ],
-  [
-    "\\downfishtail",
-    "down fish tail"
-  ],
-  [
-    "\\Vvert",
-    "triple vertical bar delimiter"
-  ],
-  [
-    "\\mdsmblkcircle",
-    "z notation spot"
-  ],
-  [
-    "\\typecolon",
-    "z notation type colon"
-  ],
-  [
-    "\\lBrace",
-    "left white curly bracket"
-  ],
-  [
-    "\\rBrace",
-    "right white curly bracket"
-  ],
-  [
-    "\\lParen",
-    "left white parenthesis"
-  ],
-  [
-    "\\rParen",
-    "right white parenthesis"
-  ],
-  [
-    "\\llparenthesis",
-    "z notation left image bracket"
-  ],
-  [
-    "\\rrparenthesis",
-    "z notation right image bracket"
-  ],
-  [
-    "\\llangle",
-    "z notation left binding bracket"
-  ],
-  [
-    "\\rrangle",
-    "z notation right binding bracket"
-  ],
-  [
-    "\\lbrackubar",
-    "left square bracket with underbar"
-  ],
-  [
-    "\\rbrackubar",
-    "right square bracket with underbar"
-  ],
-  [
-    "\\lbrackultick",
-    "left square bracket with tick in top corner"
-  ],
-  [
-    "\\rbracklrtick",
-    "right square bracket with tick in bottom corner"
-  ],
-  [
-    "\\lbracklltick",
-    "left square bracket with tick in bottom corner"
-  ],
-  [
-    "\\rbrackurtick",
-    "right square bracket with tick in top corner"
-  ],
-  [
-    "\\langledot",
-    "left angle bracket with dot"
-  ],
-  [
-    "\\rangledot",
-    "right angle bracket with dot"
-  ],
-  [
-    "\\lparenless",
-    "left arc less-than bracket"
-  ],
-  [
-    "\\rparengtr",
-    "right arc greater-than bracket"
-  ],
-  [
-    "\\Lparengtr",
-    "double left arc greater-than bracket"
-  ],
-  [
-    "\\Rparenless",
-    "double right arc less-than bracket"
-  ],
-  [
-    "\\lblkbrbrak",
-    "left black tortoise shell bracket"
-  ],
-  [
-    "\\rblkbrbrak",
-    "right black tortoise shell bracket"
-  ],
-  [
-    "\\fourvdots",
-    "dotted fence"
-  ],
-  [
-    "\\vzigzag",
-    "vertical zigzag line"
-  ],
-  [
-    "\\measuredangleleft",
-    "measured angle opening left"
-  ],
-  [
-    "\\rightanglesqr",
-    "right angle variant with square"
-  ],
-  [
-    "\\rightanglemdot",
-    "measured right angle with dot"
-  ],
-  [
-    "\\angles",
-    "angle with s inside"
-  ],
-  [
-    "\\angdnr",
-    "acute angle"
-  ],
-  [
-    "\\gtlpar",
-    "spherical angle opening left"
-  ],
-  [
-    "\\sphericalangleup",
-    "spherical angle opening up"
-  ],
-  [
-    "\\turnangle",
-    "turned angle"
-  ],
-  [
-    "\\revangle",
-    "reversed angle"
-  ],
-  [
-    "\\angleubar",
-    "angle with underbar"
-  ],
-  [
-    "\\revangleubar",
-    "reversed angle with underbar"
-  ],
-  [
-    "\\wideangledown",
-    "oblique angle opening up"
-  ],
-  [
-    "\\wideangleup",
-    "oblique angle opening down"
-  ],
-  [
-    "\\measanglerutone",
-    "measured angle with open arm ending in arrow pointing up and right"
-  ],
-  [
-    "\\measanglelutonw",
-    "measured angle with open arm ending in arrow pointing up and left"
-  ],
-  [
-    "\\measanglerdtose",
-    "measured angle with open arm ending in arrow pointing down and right"
-  ],
-  [
-    "\\measangleldtosw",
-    "measured angle with open arm ending in arrow pointing down and left"
-  ],
-  [
-    "\\measangleurtone",
-    "measured angle with open arm ending in arrow pointing right and up"
-  ],
-  [
-    "\\measangleultonw",
-    "measured angle with open arm ending in arrow pointing left and up"
-  ],
-  [
-    "\\measangledrtose",
-    "measured angle with open arm ending in arrow pointing right and down"
-  ],
-  [
-    "\\measangledltosw",
-    "measured angle with open arm ending in arrow pointing left and down"
-  ],
-  [
-    "\\revemptyset",
-    "reversed empty set"
-  ],
-  [
-    "\\emptysetobar",
-    "empty set with overbar"
-  ],
-  [
-    "\\emptysetocirc",
-    "empty set with small circle above"
-  ],
-  [
-    "\\emptysetoarr",
-    "empty set with right arrow above"
-  ],
-  [
-    "\\emptysetoarrl",
-    "empty set with left arrow above"
-  ],
-  [
-    "\\circlehbar",
-    "circle with horizontal bar"
-  ],
-  [
-    "\\circledvert",
-    "circled vertical bar"
-  ],
-  [
-    "\\circledparallel",
-    "circled parallel"
-  ],
-  [
-    "\\obslash",
-    "circled reverse solidus"
-  ],
-  [
-    "\\operp",
-    "circled perpendicular"
-  ],
-  [
-    "\\obot",
-    "circle divided by horizontal bar and top half divided by vertical bar"
-  ],
-  [
-    "\\olcross",
-    "circle with superimposed x"
-  ],
-  [
-    "\\odotslashdot",
-    "circled anticlockwise-rotated division sign"
-  ],
-  [
-    "\\uparrowoncircle",
-    "up arrow through circle"
-  ],
-  [
-    "\\circledwhitebullet",
-    "circled white bullet"
-  ],
-  [
-    "\\circledbullet",
-    "circled bullet"
-  ],
-  [
-    "\\olessthan",
-    "circled less-than"
-  ],
-  [
-    "\\ogreaterthan",
-    "circled greater-than"
-  ],
-  [
-    "\\cirscir",
-    "circle with small circle to the right"
-  ],
-  [
-    "\\cirE",
-    "circle with two horizontal strokes to the right"
-  ],
-  [
-    "\\boxdiag",
-    "squared rising diagonal slash"
-  ],
-  [
-    "\\boxbslash",
-    "squared falling diagonal slash"
-  ],
-  [
-    "\\boxast",
-    "squared asterisk"
-  ],
-  [
-    "\\boxcircle",
-    "squared small circle"
-  ],
-  [
-    "\\boxbox",
-    "squared square"
-  ],
-  [
-    "\\boxonbox",
-    "two joined squares"
-  ],
-  [
-    "\\triangleodot",
-    "triangle with dot above"
-  ],
-  [
-    "\\triangleubar",
-    "triangle with underbar"
-  ],
-  [
-    "\\triangles",
-    "s in triangle"
-  ],
-  [
-    "\\triangleserifs",
-    "triangle with serifs at bottom"
-  ],
-  [
-    "\\rtriltri",
-    "right triangle above left triangle"
-  ],
-  [
-    "\\ltrivb",
-    "left triangle beside vertical bar"
-  ],
-  [
-    "\\vbrtri",
-    "vertical bar beside right triangle"
-  ],
-  [
-    "\\lfbowtie",
-    "left black bowtie"
-  ],
-  [
-    "\\rfbowtie",
-    "right black bowtie"
-  ],
-  [
-    "\\fbowtie",
-    "black bowtie"
-  ],
-  [
-    "\\lftimes",
-    "left black times"
-  ],
-  [
-    "\\rftimes",
-    "right black times"
-  ],
-  [
-    "\\hourglass",
-    "white hourglass"
-  ],
-  [
-    "\\blackhourglass",
-    "black hourglass"
-  ],
-  [
-    "\\lvzigzag",
-    "left wiggly fence"
-  ],
-  [
-    "\\rvzigzag",
-    "right wiggly fence"
-  ],
-  [
-    "\\Lvzigzag",
-    "left double wiggly fence"
-  ],
-  [
-    "\\Rvzigzag",
-    "right double wiggly fence"
-  ],
-  [
-    "\\iinfin",
-    "incomplete infinity"
-  ],
-  [
-    "\\tieinfty",
-    "tie over infinity"
-  ],
-  [
-    "\\nvinfty",
-    "infinity negated with vertical bar"
-  ],
-  [
-    "\\dualmap",
-    "double-ended multimap"
-  ],
-  [
-    "\\laplac",
-    "square with contoured outline"
-  ],
-  [
-    "\\lrtriangleeq",
-    "increases as"
-  ],
-  [
-    "\\shuffle",
-    "shuffle product"
-  ],
-  [
-    "\\eparsl",
-    "equals sign and slanted parallel"
-  ],
-  [
-    "\\smeparsl",
-    "equals sign and slanted parallel with tilde above"
-  ],
-  [
-    "\\eqvparsl",
-    "identical to and slanted parallel"
-  ],
-  [
-    "\\gleichstark",
-    "gleich stark"
-  ],
-  [
-    "\\thermod",
-    "thermodynamic"
-  ],
-  [
-    "\\downtriangleleftblack",
-    "down-pointing triangle with left half black"
-  ],
-  [
-    "\\downtrianglerightblack",
-    "down-pointing triangle with right half black"
-  ],
-  [
-    "\\blackdiamonddownarrow",
-    "black diamond with down arrow"
-  ],
-  [
-    "\\mdlgblklozenge",
-    "black lozenge"
-  ],
-  [
-    "\\circledownarrow",
-    "white circle with down arrow"
-  ],
-  [
-    "\\blackcircledownarrow",
-    "black circle with down arrow"
-  ],
-  [
-    "\\errbarsquare",
-    "error-barred white square"
-  ],
-  [
-    "\\errbarblacksquare",
-    "error-barred black square"
-  ],
-  [
-    "\\errbardiamond",
-    "error-barred white diamond"
-  ],
-  [
-    "\\errbarblackdiamond",
-    "error-barred black diamond"
-  ],
-  [
-    "\\errbarcircle",
-    "error-barred white circle"
-  ],
-  [
-    "\\errbarblackcircle",
-    "error-barred black circle"
-  ],
-  [
-    "\\ruledelayed",
-    "rule-delayed"
-  ],
-  [
-    "\\setminus",
-    "reverse solidus operator"
-  ],
-  [
-    "\\dsol",
-    "solidus with overbar"
-  ],
-  [
-    "\\rsolbar",
-    "reverse solidus with horizontal stroke"
-  ],
-  [
-    "\\xsol",
-    "big solidus"
-  ],
-  [
-    "\\xbsol",
-    "big reverse solidus"
-  ],
-  [
-    "\\doubleplus",
-    "double plus"
-  ],
-  [
-    "\\tripleplus",
-    "triple plus"
-  ],
-  [
-    "\\lcurvyangle",
-    "left pointing curved angle bracket"
-  ],
-  [
-    "\\rcurvyangle",
-    "right pointing curved angle bracket"
-  ],
-  [
-    "\\tplus",
-    "tiny"
-  ],
-  [
-    "\\tminus",
-    "miny"
-  ],
-  [
-    "\\bigodot",
-    "n-ary circled dot operator"
-  ],
-  [
-    "\\bigoplus",
-    "n-ary circled plus operator"
-  ],
-  [
-    "\\bigotimes",
-    "n-ary circled times operator"
-  ],
-  [
-    "\\bigcupdot",
-    "n-ary union operator with dot"
-  ],
-  [
-    "\\biguplus",
-    "n-ary union operator with plus"
-  ],
-  [
-    "\\bigsqcap",
-    "n-ary square intersection operator"
-  ],
-  [
-    "\\bigsqcup",
-    "n-ary square union operator"
-  ],
-  [
-    "\\conjquant",
-    "two logical and operator"
-  ],
-  [
-    "\\disjquant",
-    "two logical or operator"
-  ],
-  [
-    "\\bigtimes",
-    "n-ary times operator"
-  ],
-  [
-    "\\modtwosum",
-    "modulo two sum"
-  ],
-  [
-    "\\sumint",
-    "summation with integral"
-  ],
-  [
-    "\\iiiint",
-    "quadruple integral operator"
-  ],
-  [
-    "\\intbar",
-    "finite part integral"
-  ],
-  [
-    "\\intBar",
-    "integral with double stroke"
-  ],
-  [
-    "\\fint",
-    "integral average with slash"
-  ],
-  [
-    "\\cirfnint",
-    "circulation function"
-  ],
-  [
-    "\\awint",
-    "anticlockwise integration"
-  ],
-  [
-    "\\rppolint",
-    "line integration with rectangular path around pole"
-  ],
-  [
-    "\\scpolint",
-    "line integration with semicircular path around pole"
-  ],
-  [
-    "\\npolint",
-    "line integration not including the pole"
-  ],
-  [
-    "\\pointint",
-    "integral around a point operator"
-  ],
-  [
-    "\\sqint",
-    "quaternion integral operator"
-  ],
-  [
-    "\\intlarhk",
-    "integral with leftwards arrow with hook"
-  ],
-  [
-    "\\intx",
-    "integral with times sign"
-  ],
-  [
-    "\\intcap",
-    "integral with intersection"
-  ],
-  [
-    "\\intcup",
-    "integral with union"
-  ],
-  [
-    "\\upint",
-    "integral with overbar"
-  ],
-  [
-    "\\lowint",
-    "integral with underbar"
-  ],
-  [
-    "\\Join",
-    "join"
-  ],
-  [
-    "\\bigtriangleleft",
-    "large left triangle operator"
-  ],
-  [
-    "\\zcmp",
-    "z notation schema composition"
-  ],
-  [
-    "\\zpipe",
-    "z notation schema piping"
-  ],
-  [
-    "\\zproject",
-    "z notation schema projection"
-  ],
-  [
-    "\\ringplus",
-    "plus sign with small circle above"
-  ],
-  [
-    "\\plushat",
-    "plus sign with circumflex accent above"
-  ],
-  [
-    "\\simplus",
-    "plus sign with tilde above"
-  ],
-  [
-    "\\plusdot",
-    "plus sign with dot below"
-  ],
-  [
-    "\\plussim",
-    "plus sign with tilde below"
-  ],
-  [
-    "\\plussubtwo",
-    "plus sign with subscript two"
-  ],
-  [
-    "\\plustrif",
-    "plus sign with black triangle"
-  ],
-  [
-    "\\commaminus",
-    "minus sign with comma above"
-  ],
-  [
-    "\\minusdot",
-    "minus sign with dot below"
-  ],
-  [
-    "\\minusfdots",
-    "minus sign with falling dots"
-  ],
-  [
-    "\\minusrdots",
-    "minus sign with rising dots"
-  ],
-  [
-    "\\opluslhrim",
-    "plus sign in left half circle"
-  ],
-  [
-    "\\oplusrhrim",
-    "plus sign in right half circle"
-  ],
-  [
-    "\\vectimes",
-    "vector or cross product"
-  ],
-  [
-    "\\dottimes",
-    "multiplication sign with dot above"
-  ],
-  [
-    "\\timesbar",
-    "multiplication sign with underbar"
-  ],
-  [
-    "\\btimes",
-    "semidirect product with bottom closed"
-  ],
-  [
-    "\\smashtimes",
-    "smash product"
-  ],
-  [
-    "\\otimeslhrim",
-    "multiplication sign in left half circle"
-  ],
-  [
-    "\\otimesrhrim",
-    "multiplication sign in right half circle"
-  ],
-  [
-    "\\otimeshat",
-    "circled multiplication sign with circumflex accent"
-  ],
-  [
-    "\\Otimes",
-    "multiplication sign in double circle"
-  ],
-  [
-    "\\odiv",
-    "circled division sign"
-  ],
-  [
-    "\\triangleplus",
-    "plus sign in triangle"
-  ],
-  [
-    "\\triangleminus",
-    "minus sign in triangle"
-  ],
-  [
-    "\\triangletimes",
-    "multiplication sign in triangle"
-  ],
-  [
-    "\\intprod",
-    "interior product"
-  ],
-  [
-    "\\intprodr",
-    "righthand interior product"
-  ],
-  [
-    "\\fcmp",
-    "z notation relational composition"
-  ],
-  [
-    "\\amalg",
-    "amalgamation or coproduct"
-  ],
-  [
-    "\\capdot",
-    "intersection with dot"
-  ],
-  [
-    "\\uminus",
-    "union with minus sign"
-  ],
-  [
-    "\\barcup",
-    "union with overbar"
-  ],
-  [
-    "\\barcap",
-    "intersection with overbar"
-  ],
-  [
-    "\\capwedge",
-    "intersection with logical and"
-  ],
-  [
-    "\\cupvee",
-    "union with logical or"
-  ],
-  [
-    "\\cupovercap",
-    "union above intersection"
-  ],
-  [
-    "\\capovercup",
-    "intersection above union"
-  ],
-  [
-    "\\cupbarcap",
-    "union above bar above intersection"
-  ],
-  [
-    "\\capbarcup",
-    "intersection above bar above union"
-  ],
-  [
-    "\\twocups",
-    "union beside and joined with union"
-  ],
-  [
-    "\\twocaps",
-    "intersection beside and joined with intersection"
-  ],
-  [
-    "\\closedvarcup",
-    "closed union with serifs"
-  ],
-  [
-    "\\closedvarcap",
-    "closed intersection with serifs"
-  ],
-  [
-    "\\Sqcap",
-    "double square intersection"
-  ],
-  [
-    "\\Sqcup",
-    "double square union"
-  ],
-  [
-    "\\closedvarcupsmashprod",
-    "closed union with serifs and smash product"
-  ],
-  [
-    "\\wedgeodot",
-    "logical and with dot above"
-  ],
-  [
-    "\\veeodot",
-    "logical or with dot above"
-  ],
-  [
-    "\\Wedge",
-    "double logical and"
-  ],
-  [
-    "\\Vee",
-    "double logical or"
-  ],
-  [
-    "\\wedgeonwedge",
-    "two intersecting logical and"
-  ],
-  [
-    "\\veeonvee",
-    "two intersecting logical or"
-  ],
-  [
-    "\\bigslopedvee",
-    "sloping large or"
-  ],
-  [
-    "\\bigslopedwedge",
-    "sloping large and"
-  ],
-  [
-    "\\veeonwedge",
-    "logical or overlapping logical and"
-  ],
-  [
-    "\\wedgemidvert",
-    "logical and with middle stem"
-  ],
-  [
-    "\\veemidvert",
-    "logical or with middle stem"
-  ],
-  [
-    "\\midbarwedge",
-    "ogical and with horizontal dash"
-  ],
-  [
-    "\\midbarvee",
-    "logical or with horizontal dash"
-  ],
-  [
-    "\\doublebarwedge",
-    "logical and with double overbar"
-  ],
-  [
-    "\\wedgebar",
-    "logical and with underbar"
-  ],
-  [
-    "\\wedgedoublebar",
-    "logical and with double underbar"
-  ],
-  [
-    "\\varveebar",
-    "small vee with underbar"
-  ],
-  [
-    "\\doublebarvee",
-    "logical or with double overbar"
-  ],
-  [
-    "\\veedoublebar",
-    "logical or with double underbar"
-  ],
-  [
-    "\\dsub",
-    "z notation domain antirestriction"
-  ],
-  [
-    "\\rsub",
-    "z notation range antirestriction"
-  ],
-  [
-    "\\eqdot",
-    "equals sign with dot below"
-  ],
-  [
-    "\\dotequiv",
-    "identical with dot above"
-  ],
-  [
-    "\\equivVert",
-    "triple horizontal bar with double vertical stroke"
-  ],
-  [
-    "\\equivVvert",
-    "triple horizontal bar with triple vertical stroke"
-  ],
-  [
-    "\\dotsim",
-    "tilde operator with dot above"
-  ],
-  [
-    "\\simrdots",
-    "tilde operator with rising dots"
-  ],
-  [
-    "\\simminussim",
-    "similar minus similar"
-  ],
-  [
-    "\\congdot",
-    "congruent with dot above"
-  ],
-  [
-    "\\asteq",
-    "equals with asterisk"
-  ],
-  [
-    "\\hatapprox",
-    "almost equal to with circumflex accent"
-  ],
-  [
-    "\\approxeqq",
-    "approximately equal or equal to"
-  ],
-  [
-    "\\eqqplus",
-    "equals sign above plus sign"
-  ],
-  [
-    "\\pluseqq",
-    "plus sign above equals sign"
-  ],
-  [
-    "\\eqqsim",
-    "equals sign above tilde operator"
-  ],
-  [
-    "\\Coloneq",
-    "double colon equal"
-  ],
-  [
-    "\\eqeq",
-    "two consecutive equals signs"
-  ],
-  [
-    "\\eqeqeq",
-    "three consecutive equals signs"
-  ],
-  [
-    "\\ddotseq",
-    "equals sign with two dots above and two dots below"
-  ],
-  [
-    "\\equivDD",
-    "equivalent with four dots above"
-  ],
-  [
-    "\\ltcir",
-    "less-than with circle inside"
-  ],
-  [
-    "\\gtcir",
-    "greater-than with circle inside"
-  ],
-  [
-    "\\ltquest",
-    "less-than with question mark above"
-  ],
-  [
-    "\\gtquest",
-    "greater-than with question mark above"
-  ],
-  [
-    "\\leqslant",
-    "less-than or slanted equal to"
-  ],
-  [
-    "\\geqslant",
-    "greater-than or slanted equal to"
-  ],
-  [
-    "\\lesdot",
-    "less-than or slanted equal to with dot inside"
-  ],
-  [
-    "\\gesdot",
-    "greater-than or slanted equal to with dot inside"
-  ],
-  [
-    "\\lesdoto",
-    "less-than or slanted equal to with dot above"
-  ],
-  [
-    "\\gesdoto",
-    "greater-than or slanted equal to with dot above"
-  ],
-  [
-    "\\lesdotor",
-    "less-than or slanted equal to with dot above right"
-  ],
-  [
-    "\\gesdotol",
-    "greater-than or slanted equal to with dot above left"
-  ],
-  [
-    "\\lessapprox",
-    "less-than or approximate"
-  ],
-  [
-    "\\gtrapprox",
-    "greater-than or approximate"
-  ],
-  [
-    "\\lneq",
-    "less-than and single-line not equal to"
-  ],
-  [
-    "\\gneq",
-    "greater-than and single-line not equal to"
-  ],
-  [
-    "\\lnapprox",
-    "less-than and not approximate"
-  ],
-  [
-    "\\gnapprox",
-    "greater-than and not approximate"
-  ],
-  [
-    "\\lesseqqgtr",
-    "less-than above double-line equal above greater-than"
-  ],
-  [
-    "\\gtreqqless",
-    "greater-than above double-line equal above less-than"
-  ],
-  [
-    "\\lsime",
-    "less-than above similar or equal"
-  ],
-  [
-    "\\gsime",
-    "greater-than above similar or equal"
-  ],
-  [
-    "\\lsimg",
-    "less-than above similar above greater-than"
-  ],
-  [
-    "\\gsiml",
-    "greater-than above similar above less-than"
-  ],
-  [
-    "\\lgE",
-    "less-than above greater-than above double-line equal"
-  ],
-  [
-    "\\glE",
-    "greater-than above less-than above double-line equal"
-  ],
-  [
-    "\\lesges",
-    "less-than above slanted equal above greater-than above slanted equal"
-  ],
-  [
-    "\\gesles",
-    "greater-than above slanted equal above less-than above slanted equal"
-  ],
-  [
-    "\\eqslantless",
-    "slanted equal to or less-than"
-  ],
-  [
-    "\\eqslantgtr",
-    "slanted equal to or greater-than"
-  ],
-  [
-    "\\elsdot",
-    "slanted equal to or less-than with dot inside"
-  ],
-  [
-    "\\egsdot",
-    "slanted equal to or greater-than with dot inside"
-  ],
-  [
-    "\\eqqless",
-    "double-line equal to or less-than"
-  ],
-  [
-    "\\eqqgtr",
-    "double-line equal to or greater-than"
-  ],
-  [
-    "\\eqqslantless",
-    "double-line slanted equal to or less-than"
-  ],
-  [
-    "\\eqqslantgtr",
-    "double-line slanted equal to or greater-than"
-  ],
-  [
-    "\\simless",
-    "similar or less-than"
-  ],
-  [
-    "\\simgtr",
-    "similar or greater-than"
-  ],
-  [
-    "\\simlE",
-    "similar above less-than above equals sign"
-  ],
-  [
-    "\\simgE",
-    "similar above greater-than above equals sign"
-  ],
-  [
-    "\\Lt",
-    "double nested less-than"
-  ],
-  [
-    "\\Gt",
-    "double nested greater-than"
-  ],
-  [
-    "\\partialmeetcontraction",
-    "double less-than with underbar"
-  ],
-  [
-    "\\glj",
-    "greater-than overlapping less-than"
-  ],
-  [
-    "\\gla",
-    "greater-than beside less-than"
-  ],
-  [
-    "\\ltcc",
-    "less-than closed by curve"
-  ],
-  [
-    "\\gtcc",
-    "greater-than closed by curve"
-  ],
-  [
-    "\\lescc",
-    "less-than closed by curve above slanted equal"
-  ],
-  [
-    "\\gescc",
-    "greater-than closed by curve above slanted equal"
-  ],
-  [
-    "\\smt",
-    "smaller than"
-  ],
-  [
-    "\\lat",
-    "larger than"
-  ],
-  [
-    "\\smte",
-    "smaller than or equal to"
-  ],
-  [
-    "\\late",
-    "larger than or equal to"
-  ],
-  [
-    "\\bumpeqq",
-    "equals sign with bumpy above"
-  ],
-  [
-    "\\preceq",
-    "precedes above single-line equals sign"
-  ],
-  [
-    "\\succeq",
-    "succeeds above single-line equals sign"
-  ],
-  [
-    "\\precneq",
-    "precedes above single-line not equal to"
-  ],
-  [
-    "\\succneq",
-    "succeeds above single-line not equal to"
-  ],
-  [
-    "\\preceqq",
-    "precedes above equals sign"
-  ],
-  [
-    "\\succeqq",
-    "succeeds above equals sign"
-  ],
-  [
-    "\\precneqq",
-    "precedes above not equal to"
-  ],
-  [
-    "\\succneqq",
-    "succeeds above not equal to"
-  ],
-  [
-    "\\precapprox",
-    "precedes above almost equal to"
-  ],
-  [
-    "\\succapprox",
-    "succeeds above almost equal to"
-  ],
-  [
-    "\\precnapprox",
-    "precedes above not almost equal to"
-  ],
-  [
-    "\\succnapprox",
-    "succeeds above not almost equal to"
-  ],
-  [
-    "\\Prec",
-    "double precedes"
-  ],
-  [
-    "\\Succ",
-    "double succeeds"
-  ],
-  [
-    "\\subsetdot",
-    "subset with dot"
-  ],
-  [
-    "\\supsetdot",
-    "superset with dot"
-  ],
-  [
-    "\\subsetplus",
-    "subset with plus sign below"
-  ],
-  [
-    "\\supsetplus",
-    "superset with plus sign below"
-  ],
-  [
-    "\\submult",
-    "subset with multiplication sign below"
-  ],
-  [
-    "\\supmult",
-    "superset with multiplication sign below"
-  ],
-  [
-    "\\subedot",
-    "subset of or equal to with dot above"
-  ],
-  [
-    "\\supedot",
-    "superset of or equal to with dot above"
-  ],
-  [
-    "\\subseteqq",
-    "subset of above equals sign"
-  ],
-  [
-    "\\supseteqq",
-    "superset of above equals sign"
-  ],
-  [
-    "\\subsim",
-    "subset of above tilde operator"
-  ],
-  [
-    "\\supsim",
-    "superset of above tilde operator"
-  ],
-  [
-    "\\subsetapprox",
-    "subset of above almost equal to"
-  ],
-  [
-    "\\supsetapprox",
-    "superset of above almost equal to"
-  ],
-  [
-    "\\subsetneqq",
-    "subset of above not equal to"
-  ],
-  [
-    "\\supsetneqq",
-    "superset of above not equal to"
-  ],
-  [
-    "\\lsqhook",
-    "square left open box operator"
-  ],
-  [
-    "\\rsqhook",
-    "square right open box operator"
-  ],
-  [
-    "\\csub",
-    "closed subset"
-  ],
-  [
-    "\\csup",
-    "closed superset"
-  ],
-  [
-    "\\csube",
-    "closed subset or equal to"
-  ],
-  [
-    "\\csupe",
-    "closed superset or equal to"
-  ],
-  [
-    "\\subsup",
-    "subset above superset"
-  ],
-  [
-    "\\supsub",
-    "superset above subset"
-  ],
-  [
-    "\\subsub",
-    "subset above subset"
-  ],
-  [
-    "\\supsup",
-    "superset above superset"
-  ],
-  [
-    "\\suphsub",
-    "superset beside subset"
-  ],
-  [
-    "\\supdsub",
-    "superset beside and joined by dash with subset"
-  ],
-  [
-    "\\forkv",
-    "element of opening downwards"
-  ],
-  [
-    "\\topfork",
-    "pitchfork with tee top"
-  ],
-  [
-    "\\mlcp",
-    "transversal intersection"
-  ],
-  [
-    "\\forks",
-    "forking"
-  ],
-  [
-    "\\forksnot",
-    "nonforking"
-  ],
-  [
-    "\\shortlefttack",
-    "short left tack"
-  ],
-  [
-    "\\shortdowntack",
-    "short down tack"
-  ],
-  [
-    "\\shortuptack",
-    "short up tack"
-  ],
-  [
-    "\\perps",
-    "perpendicular with s"
-  ],
-  [
-    "\\vDdash",
-    "vertical bar triple right turnstile"
-  ],
-  [
-    "\\dashV",
-    "double vertical bar left turnstile"
-  ],
-  [
-    "\\Dashv",
-    "vertical bar double left turnstile"
-  ],
-  [
-    "\\DashV",
-    "double vertical bar double left turnstile"
-  ],
-  [
-    "\\varVdash",
-    "long dash from left member of double vertical"
-  ],
-  [
-    "\\Barv",
-    "short down tack with overbar"
-  ],
-  [
-    "\\vBar",
-    "short up tack with underbar"
-  ],
-  [
-    "\\vBarv",
-    "short up tack above short down tack"
-  ],
-  [
-    "\\barV",
-    "double down tack"
-  ],
-  [
-    "\\Vbar",
-    "double up tack"
-  ],
-  [
-    "\\Not",
-    "double stroke not sign"
-  ],
-  [
-    "\\bNot",
-    "reversed double stroke not sign"
-  ],
-  [
-    "\\revnmid",
-    "does not divide with reversed negation slash"
-  ],
-  [
-    "\\cirmid",
-    "vertical line with circle above"
-  ],
-  [
-    "\\midcir",
-    "vertical line with circle below"
-  ],
-  [
-    "\\topcir",
-    "down tack with circle below"
-  ],
-  [
-    "\\nhpar",
-    "parallel with horizontal stroke"
-  ],
-  [
-    "\\parsim",
-    "parallel with tilde operator"
-  ],
-  [
-    "\\interleave",
-    "triple vertical bar binary relation"
-  ],
-  [
-    "\\nhVvert",
-    "triple vertical bar with horizontal stroke"
-  ],
-  [
-    "\\threedotcolon",
-    "triple colon operator"
-  ],
-  [
-    "\\lllnest",
-    "stacked very much less-than"
-  ],
-  [
-    "\\gggnest",
-    "stacked very much greater-than"
-  ],
-  [
-    "\\leqqslant",
-    "double-line slanted less-than or equal to"
-  ],
-  [
-    "\\geqqslant",
-    "double-line slanted greater-than or equal to"
-  ],
-  [
-    "\\trslash",
-    "triple solidus binary relation"
-  ],
-  [
-    "\\biginterleave",
-    "large triple vertical bar operator"
-  ],
-  [
-    "\\sslash",
-    "double solidus operator"
-  ],
-  [
-    "\\talloblong",
-    "white vertical bar"
-  ],
-  [
-    "\\bigtalloblong",
-    "n-ary white vertical bar"
-  ],
-  [
-    "\\squaretopblack",
-    "square with top half black"
-  ],
-  [
-    "\\squarebotblack",
-    "square with bottom half black"
-  ],
-  [
-    "\\squareurblack",
-    "square with upper right diagonal half black"
-  ],
-  [
-    "\\squarellblack",
-    "square with lower left diagonal half black"
-  ],
-  [
-    "\\diamondleftblack",
-    "diamond with left half black"
-  ],
-  [
-    "\\diamondrightblack",
-    "diamond with right half black"
-  ],
-  [
-    "\\diamondtopblack",
-    "diamond with top half black"
-  ],
-  [
-    "\\diamondbotblack",
-    "diamond with bottom half black"
-  ],
-  [
-    "\\dottedsquare",
-    "dotted square"
-  ],
-  [
-    "\\lgblksquare",
-    "black large square"
-  ],
-  [
-    "\\lgwhtsquare",
-    "white large square"
-  ],
-  [
-    "\\vysmblksquare",
-    "black very small square"
-  ],
-  [
-    "\\vysmwhtsquare",
-    "white very small square"
-  ],
-  [
-    "\\pentagonblack",
-    "black pentagon"
-  ],
-  [
-    "\\pentagon",
-    "white pentagon"
-  ],
-  [
-    "\\varhexagon",
-    "white hexagon"
-  ],
-  [
-    "\\varhexagonblack",
-    "black hexagon"
-  ],
-  [
-    "\\hexagonblack",
-    "horizontal black hexagon"
-  ],
-  [
-    "\\lgblkcircle",
-    "black large circle"
-  ],
-  [
-    "\\mdblkdiamond",
-    "black medium diamond"
-  ],
-  [
-    "\\mdwhtdiamond",
-    "white medium diamond"
-  ],
-  [
-    "\\mdblklozenge",
-    "black medium lozenge"
-  ],
-  [
-    "\\mdwhtlozenge",
-    "white medium lozenge"
-  ],
-  [
-    "\\smblkdiamond",
-    "black small diamond"
-  ],
-  [
-    "\\smblklozenge",
-    "black small lozenge"
-  ],
-  [
-    "\\smwhtlozenge",
-    "white small lozenge"
-  ],
-  [
-    "\\blkhorzoval",
-    "black horizontal ellipse"
-  ],
-  [
-    "\\whthorzoval",
-    "white horizontal ellipse"
-  ],
-  [
-    "\\blkvertoval",
-    "black vertical ellipse"
-  ],
-  [
-    "\\whtvertoval",
-    "white vertical ellipse"
-  ],
-  [
-    "\\circleonleftarrow",
-    "left arrow with small circle"
-  ],
-  [
-    "\\leftthreearrows",
-    "three leftwards arrows"
-  ],
-  [
-    "\\leftarrowonoplus",
-    "left arrow with circled plus"
-  ],
-  [
-    "\\longleftsquigarrow",
-    "long leftwards squiggle arrow"
-  ],
-  [
-    "\\nvtwoheadleftarrow",
-    "leftwards two-headed arrow with vertical stroke"
-  ],
-  [
-    "\\nVtwoheadleftarrow",
-    "leftwards two-headed arrow with double vertical stroke"
-  ],
-  [
-    "\\twoheadmapsfrom",
-    "leftwards two-headed arrow from bar"
-  ],
-  [
-    "\\twoheadleftdbkarrow",
-    "leftwards two-headed triple-dash arrow"
-  ],
-  [
-    "\\leftdotarrow",
-    "leftwards arrow with dotted stem"
-  ],
-  [
-    "\\nvleftarrowtail",
-    "leftwards arrow with tail with vertical stroke"
-  ],
-  [
-    "\\nVleftarrowtail",
-    "leftwards arrow with tail with double vertical stroke"
-  ],
-  [
-    "\\twoheadleftarrowtail",
-    "leftwards two-headed arrow with tail"
-  ],
-  [
-    "\\nvtwoheadleftarrowtail",
-    "leftwards two-headed arrow with tail with vertical stroke"
-  ],
-  [
-    "\\nVtwoheadleftarrowtail",
-    "leftwards two-headed arrow with tail with double vertical stroke"
-  ],
-  [
-    "\\leftarrowx",
-    "leftwards arrow through x"
-  ],
-  [
-    "\\leftcurvedarrow",
-    "wave arrow pointing directly left"
-  ],
-  [
-    "\\equalleftarrow",
-    "equals sign above leftwards arrow"
-  ],
-  [
-    "\\bsimilarleftarrow",
-    "reverse tilde operator above leftwards arrow"
-  ],
-  [
-    "\\leftarrowbackapprox",
-    "leftwards arrow above reverse almost equal to"
-  ],
-  [
-    "\\rightarrowgtr",
-    "rightwards arrow through greater-than"
-  ],
-  [
-    "\\rightarrowsupset",
-    "rightwards arrow through subset"
-  ],
-  [
-    "\\LLeftarrow",
-    "leftwards quadruple arrow"
-  ],
-  [
-    "\\RRightarrow",
-    "rightwards quadruple arrow"
-  ],
-  [
-    "\\bsimilarrightarrow",
-    "reverse tilde operator above rightwards arrow"
-  ],
-  [
-    "\\rightarrowbackapprox",
-    "rightwards arrow above reverse almost equal to"
-  ],
-  [
-    "\\similarleftarrow",
-    "tilde operator above leftwards arrow"
-  ],
-  [
-    "\\leftarrowapprox",
-    "leftwards arrow above almost equal to"
-  ],
-  [
-    "\\leftarrowbsimilar",
-    "leftwards arrow above reverse tilde operator"
-  ],
-  [
-    "\\rightarrowbsimilar",
-    "righttwards arrow above reverse tilde operator"
-  ],
-  [
-    "\\medwhitestar",
-    "white medium star"
-  ],
-  [
-    "\\medblackstar",
-    "black medium star"
-  ],
-  [
-    "\\smwhitestar",
-    "white small star"
-  ],
-  [
-    "\\rightpentagonblack",
-    "black right-pointing pentagon"
-  ],
-  [
-    "\\rightpentagon",
-    "white right-pointing pentagon"
-  ],
-  [
-    "\\postalmark",
-    "postal mark"
-  ],
-  [
-    "\\hzigzag",
-    "zigzag"
-  ],
-  [
-    "\\mbfA",
-    "mathematical bold capital a"
-  ],
-  [
-    "\\mbfB",
-    "mathematical bold capital b"
-  ],
-  [
-    "\\mbfC",
-    "mathematical bold capital c"
-  ],
-  [
-    "\\mbfD",
-    "mathematical bold capital d"
-  ],
-  [
-    "\\mbfE",
-    "mathematical bold capital e"
-  ],
-  [
-    "\\mbfF",
-    "mathematical bold capital f"
-  ],
-  [
-    "\\mbfG",
-    "mathematical bold capital g"
-  ],
-  [
-    "\\mbfH",
-    "mathematical bold capital h"
-  ],
-  [
-    "\\mbfI",
-    "mathematical bold capital i"
-  ],
-  [
-    "\\mbfJ",
-    "mathematical bold capital j"
-  ],
-  [
-    "\\mbfK",
-    "mathematical bold capital k"
-  ],
-  [
-    "\\mbfL",
-    "mathematical bold capital l"
-  ],
-  [
-    "\\mbfM",
-    "mathematical bold capital m"
-  ],
-  [
-    "\\mbfN",
-    "mathematical bold capital n"
-  ],
-  [
-    "\\mbfO",
-    "mathematical bold capital o"
-  ],
-  [
-    "\\mbfP",
-    "mathematical bold capital p"
-  ],
-  [
-    "\\mbfQ",
-    "mathematical bold capital q"
-  ],
-  [
-    "\\mbfR",
-    "mathematical bold capital r"
-  ],
-  [
-    "\\mbfS",
-    "mathematical bold capital s"
-  ],
-  [
-    "\\mbfT",
-    "mathematical bold capital t"
-  ],
-  [
-    "\\mbfU",
-    "mathematical bold capital u"
-  ],
-  [
-    "\\mbfV",
-    "mathematical bold capital v"
-  ],
-  [
-    "\\mbfW",
-    "mathematical bold capital w"
-  ],
-  [
-    "\\mbfX",
-    "mathematical bold capital x"
-  ],
-  [
-    "\\mbfY",
-    "mathematical bold capital y"
-  ],
-  [
-    "\\mbfZ",
-    "mathematical bold capital z"
-  ],
-  [
-    "\\mbfa",
-    "mathematical bold small a"
-  ],
-  [
-    "\\mbfb",
-    "mathematical bold small b"
-  ],
-  [
-    "\\mbfc",
-    "mathematical bold small c"
-  ],
-  [
-    "\\mbfd",
-    "mathematical bold small d"
-  ],
-  [
-    "\\mbfe",
-    "mathematical bold small e"
-  ],
-  [
-    "\\mbff",
-    "mathematical bold small f"
-  ],
-  [
-    "\\mbfg",
-    "mathematical bold small g"
-  ],
-  [
-    "\\mbfh",
-    "mathematical bold small h"
-  ],
-  [
-    "\\mbfi",
-    "mathematical bold small i"
-  ],
-  [
-    "\\mbfj",
-    "mathematical bold small j"
-  ],
-  [
-    "\\mbfk",
-    "mathematical bold small k"
-  ],
-  [
-    "\\mbfl",
-    "mathematical bold small l"
-  ],
-  [
-    "\\mbfm",
-    "mathematical bold small m"
-  ],
-  [
-    "\\mbfn",
-    "mathematical bold small n"
-  ],
-  [
-    "\\mbfo",
-    "mathematical bold small o"
-  ],
-  [
-    "\\mbfp",
-    "mathematical bold small p"
-  ],
-  [
-    "\\mbfq",
-    "mathematical bold small q"
-  ],
-  [
-    "\\mbfr",
-    "mathematical bold small r"
-  ],
-  [
-    "\\mbfs",
-    "mathematical bold small s"
-  ],
-  [
-    "\\mbft",
-    "mathematical bold small t"
-  ],
-  [
-    "\\mbfu",
-    "mathematical bold small u"
-  ],
-  [
-    "\\mbfv",
-    "mathematical bold small v"
-  ],
-  [
-    "\\mbfw",
-    "mathematical bold small w"
-  ],
-  [
-    "\\mbfx",
-    "mathematical bold small x"
-  ],
-  [
-    "\\mbfy",
-    "mathematical bold small y"
-  ],
-  [
-    "\\mbfz",
-    "mathematical bold small z"
-  ],
-  [
-    "\\mitA",
-    "mathematical italic capital a"
-  ],
-  [
-    "\\mitB",
-    "mathematical italic capital b"
-  ],
-  [
-    "\\mitC",
-    "mathematical italic capital c"
-  ],
-  [
-    "\\mitD",
-    "mathematical italic capital d"
-  ],
-  [
-    "\\mitE",
-    "mathematical italic capital e"
-  ],
-  [
-    "\\mitF",
-    "mathematical italic capital f"
-  ],
-  [
-    "\\mitG",
-    "mathematical italic capital g"
-  ],
-  [
-    "\\mitH",
-    "mathematical italic capital h"
-  ],
-  [
-    "\\mitI",
-    "mathematical italic capital i"
-  ],
-  [
-    "\\mitJ",
-    "mathematical italic capital j"
-  ],
-  [
-    "\\mitK",
-    "mathematical italic capital k"
-  ],
-  [
-    "\\mitL",
-    "mathematical italic capital l"
-  ],
-  [
-    "\\mitM",
-    "mathematical italic capital m"
-  ],
-  [
-    "\\mitN",
-    "mathematical italic capital n"
-  ],
-  [
-    "\\mitO",
-    "mathematical italic capital o"
-  ],
-  [
-    "\\mitP",
-    "mathematical italic capital p"
-  ],
-  [
-    "\\mitQ",
-    "mathematical italic capital q"
-  ],
-  [
-    "\\mitR",
-    "mathematical italic capital r"
-  ],
-  [
-    "\\mitS",
-    "mathematical italic capital s"
-  ],
-  [
-    "\\mitT",
-    "mathematical italic capital t"
-  ],
-  [
-    "\\mitU",
-    "mathematical italic capital u"
-  ],
-  [
-    "\\mitV",
-    "mathematical italic capital v"
-  ],
-  [
-    "\\mitW",
-    "mathematical italic capital w"
-  ],
-  [
-    "\\mitX",
-    "mathematical italic capital x"
-  ],
-  [
-    "\\mitY",
-    "mathematical italic capital y"
-  ],
-  [
-    "\\mitZ",
-    "mathematical italic capital z"
-  ],
-  [
-    "\\mita",
-    "mathematical italic small a"
-  ],
-  [
-    "\\mitb",
-    "mathematical italic small b"
-  ],
-  [
-    "\\mitc",
-    "mathematical italic small c"
-  ],
-  [
-    "\\mitd",
-    "mathematical italic small d"
-  ],
-  [
-    "\\mite",
-    "mathematical italic small e"
-  ],
-  [
-    "\\mitf",
-    "mathematical italic small f"
-  ],
-  [
-    "\\mitg",
-    "mathematical italic small g"
-  ],
-  [
-    "\\miti",
-    "mathematical italic small i"
-  ],
-  [
-    "\\mitj",
-    "mathematical italic small j"
-  ],
-  [
-    "\\mitk",
-    "mathematical italic small k"
-  ],
-  [
-    "\\mitl",
-    "mathematical italic small l"
-  ],
-  [
-    "\\mitm",
-    "mathematical italic small m"
-  ],
-  [
-    "\\mitn",
-    "mathematical italic small n"
-  ],
-  [
-    "\\mito",
-    "mathematical italic small o"
-  ],
-  [
-    "\\mitp",
-    "mathematical italic small p"
-  ],
-  [
-    "\\mitq",
-    "mathematical italic small q"
-  ],
-  [
-    "\\mitr",
-    "mathematical italic small r"
-  ],
-  [
-    "\\mits",
-    "mathematical italic small s"
-  ],
-  [
-    "\\mitt",
-    "mathematical italic small t"
-  ],
-  [
-    "\\mitu",
-    "mathematical italic small u"
-  ],
-  [
-    "\\mitv",
-    "mathematical italic small v"
-  ],
-  [
-    "\\mitw",
-    "mathematical italic small w"
-  ],
-  [
-    "\\mitx",
-    "mathematical italic small x"
-  ],
-  [
-    "\\mity",
-    "mathematical italic small y"
-  ],
-  [
-    "\\mitz",
-    "mathematical italic small z"
-  ],
-  [
-    "\\mbfitA",
-    "mathematical bold italic capital a"
-  ],
-  [
-    "\\mbfitB",
-    "mathematical bold italic capital b"
-  ],
-  [
-    "\\mbfitC",
-    "mathematical bold italic capital c"
-  ],
-  [
-    "\\mbfitD",
-    "mathematical bold italic capital d"
-  ],
-  [
-    "\\mbfitE",
-    "mathematical bold italic capital e"
-  ],
-  [
-    "\\mbfitF",
-    "mathematical bold italic capital f"
-  ],
-  [
-    "\\mbfitG",
-    "mathematical bold italic capital g"
-  ],
-  [
-    "\\mbfitH",
-    "mathematical bold italic capital h"
-  ],
-  [
-    "\\mbfitI",
-    "mathematical bold italic capital i"
-  ],
-  [
-    "\\mbfitJ",
-    "mathematical bold italic capital j"
-  ],
-  [
-    "\\mbfitK",
-    "mathematical bold italic capital k"
-  ],
-  [
-    "\\mbfitL",
-    "mathematical bold italic capital l"
-  ],
-  [
-    "\\mbfitM",
-    "mathematical bold italic capital m"
-  ],
-  [
-    "\\mbfitN",
-    "mathematical bold italic capital n"
-  ],
-  [
-    "\\mbfitO",
-    "mathematical bold italic capital o"
-  ],
-  [
-    "\\mbfitP",
-    "mathematical bold italic capital p"
-  ],
-  [
-    "\\mbfitQ",
-    "mathematical bold italic capital q"
-  ],
-  [
-    "\\mbfitR",
-    "mathematical bold italic capital r"
-  ],
-  [
-    "\\mbfitS",
-    "mathematical bold italic capital s"
-  ],
-  [
-    "\\mbfitT",
-    "mathematical bold italic capital t"
-  ],
-  [
-    "\\mbfitU",
-    "mathematical bold italic capital u"
-  ],
-  [
-    "\\mbfitV",
-    "mathematical bold italic capital v"
-  ],
-  [
-    "\\mbfitW",
-    "mathematical bold italic capital w"
-  ],
-  [
-    "\\mbfitX",
-    "mathematical bold italic capital x"
-  ],
-  [
-    "\\mbfitY",
-    "mathematical bold italic capital y"
-  ],
-  [
-    "\\mbfitZ",
-    "mathematical bold italic capital z"
-  ],
-  [
-    "\\mbfita",
-    "mathematical bold italic small a"
-  ],
-  [
-    "\\mbfitb",
-    "mathematical bold italic small b"
-  ],
-  [
-    "\\mbfitc",
-    "mathematical bold italic small c"
-  ],
-  [
-    "\\mbfitd",
-    "mathematical bold italic small d"
-  ],
-  [
-    "\\mbfite",
-    "mathematical bold italic small e"
-  ],
-  [
-    "\\mbfitf",
-    "mathematical bold italic small f"
-  ],
-  [
-    "\\mbfitg",
-    "mathematical bold italic small g"
-  ],
-  [
-    "\\mbfith",
-    "mathematical bold italic small h"
-  ],
-  [
-    "\\mbfiti",
-    "mathematical bold italic small i"
-  ],
-  [
-    "\\mbfitj",
-    "mathematical bold italic small j"
-  ],
-  [
-    "\\mbfitk",
-    "mathematical bold italic small k"
-  ],
-  [
-    "\\mbfitl",
-    "mathematical bold italic small l"
-  ],
-  [
-    "\\mbfitm",
-    "mathematical bold italic small m"
-  ],
-  [
-    "\\mbfitn",
-    "mathematical bold italic small n"
-  ],
-  [
-    "\\mbfito",
-    "mathematical bold italic small o"
-  ],
-  [
-    "\\mbfitp",
-    "mathematical bold italic small p"
-  ],
-  [
-    "\\mbfitq",
-    "mathematical bold italic small q"
-  ],
-  [
-    "\\mbfitr",
-    "mathematical bold italic small r"
-  ],
-  [
-    "\\mbfits",
-    "mathematical bold italic small s"
-  ],
-  [
-    "\\mbfitt",
-    "mathematical bold italic small t"
-  ],
-  [
-    "\\mbfitu",
-    "mathematical bold italic small u"
-  ],
-  [
-    "\\mbfitv",
-    "mathematical bold italic small v"
-  ],
-  [
-    "\\mbfitw",
-    "mathematical bold italic small w"
-  ],
-  [
-    "\\mbfitx",
-    "mathematical bold italic small x"
-  ],
-  [
-    "\\mbfity",
-    "mathematical bold italic small y"
-  ],
-  [
-    "\\mbfitz",
-    "mathematical bold italic small z"
-  ],
-  [
-    "\\mscrA",
-    "mathematical script capital a"
-  ],
-  [
-    "\\mscrC",
-    "mathematical script capital c"
-  ],
-  [
-    "\\mscrD",
-    "mathematical script capital d"
-  ],
-  [
-    "\\mscrG",
-    "mathematical script capital g"
-  ],
-  [
-    "\\mscrJ",
-    "mathematical script capital j"
-  ],
-  [
-    "\\mscrK",
-    "mathematical script capital k"
-  ],
-  [
-    "\\mscrN",
-    "mathematical script capital n"
-  ],
-  [
-    "\\mscrO",
-    "mathematical script capital o"
-  ],
-  [
-    "\\mscrP",
-    "mathematical script capital p"
-  ],
-  [
-    "\\mscrQ",
-    "mathematical script capital q"
-  ],
-  [
-    "\\mscrS",
-    "mathematical script capital s"
-  ],
-  [
-    "\\mscrT",
-    "mathematical script capital t"
-  ],
-  [
-    "\\mscrU",
-    "mathematical script capital u"
-  ],
-  [
-    "\\mscrV",
-    "mathematical script capital v"
-  ],
-  [
-    "\\mscrW",
-    "mathematical script capital w"
-  ],
-  [
-    "\\mscrX",
-    "mathematical script capital x"
-  ],
-  [
-    "\\mscrY",
-    "mathematical script capital y"
-  ],
-  [
-    "\\mscrZ",
-    "mathematical script capital z"
-  ],
-  [
-    "\\mscra",
-    "mathematical script small a"
-  ],
-  [
-    "\\mscrb",
-    "mathematical script small b"
-  ],
-  [
-    "\\mscrc",
-    "mathematical script small c"
-  ],
-  [
-    "\\mscrd",
-    "mathematical script small d"
-  ],
-  [
-    "\\mscrf",
-    "mathematical script small f"
-  ],
-  [
-    "\\mscrh",
-    "mathematical script small h"
-  ],
-  [
-    "\\mscri",
-    "mathematical script small i"
-  ],
-  [
-    "\\mscrj",
-    "mathematical script small j"
-  ],
-  [
-    "\\mscrk",
-    "mathematical script small k"
-  ],
-  [
-    "\\mscrl",
-    "mathematical script small l"
-  ],
-  [
-    "\\mscrm",
-    "mathematical script small m"
-  ],
-  [
-    "\\mscrn",
-    "mathematical script small n"
-  ],
-  [
-    "\\mscrp",
-    "mathematical script small p"
-  ],
-  [
-    "\\mscrq",
-    "mathematical script small q"
-  ],
-  [
-    "\\mscrr",
-    "mathematical script small r"
-  ],
-  [
-    "\\mscrs",
-    "mathematical script small s"
-  ],
-  [
-    "\\mscrt",
-    "mathematical script small t"
-  ],
-  [
-    "\\mscru",
-    "mathematical script small u"
-  ],
-  [
-    "\\mscrv",
-    "mathematical script small v"
-  ],
-  [
-    "\\mscrw",
-    "mathematical script small w"
-  ],
-  [
-    "\\mscrx",
-    "mathematical script small x"
-  ],
-  [
-    "\\mscry",
-    "mathematical script small y"
-  ],
-  [
-    "\\mscrz",
-    "mathematical script small z"
-  ],
-  [
-    "\\mbfscrA",
-    "mathematical bold script capital a"
-  ],
-  [
-    "\\mbfscrB",
-    "mathematical bold script capital b"
-  ],
-  [
-    "\\mbfscrC",
-    "mathematical bold script capital c"
-  ],
-  [
-    "\\mbfscrD",
-    "mathematical bold script capital d"
-  ],
-  [
-    "\\mbfscrE",
-    "mathematical bold script capital e"
-  ],
-  [
-    "\\mbfscrF",
-    "mathematical bold script capital f"
-  ],
-  [
-    "\\mbfscrG",
-    "mathematical bold script capital g"
-  ],
-  [
-    "\\mbfscrH",
-    "mathematical bold script capital h"
-  ],
-  [
-    "\\mbfscrI",
-    "mathematical bold script capital i"
-  ],
-  [
-    "\\mbfscrJ",
-    "mathematical bold script capital j"
-  ],
-  [
-    "\\mbfscrK",
-    "mathematical bold script capital k"
-  ],
-  [
-    "\\mbfscrL",
-    "mathematical bold script capital l"
-  ],
-  [
-    "\\mbfscrM",
-    "mathematical bold script capital m"
-  ],
-  [
-    "\\mbfscrN",
-    "mathematical bold script capital n"
-  ],
-  [
-    "\\mbfscrO",
-    "mathematical bold script capital o"
-  ],
-  [
-    "\\mbfscrP",
-    "mathematical bold script capital p"
-  ],
-  [
-    "\\mbfscrQ",
-    "mathematical bold script capital q"
-  ],
-  [
-    "\\mbfscrR",
-    "mathematical bold script capital r"
-  ],
-  [
-    "\\mbfscrS",
-    "mathematical bold script capital s"
-  ],
-  [
-    "\\mbfscrT",
-    "mathematical bold script capital t"
-  ],
-  [
-    "\\mbfscrU",
-    "mathematical bold script capital u"
-  ],
-  [
-    "\\mbfscrV",
-    "mathematical bold script capital v"
-  ],
-  [
-    "\\mbfscrW",
-    "mathematical bold script capital w"
-  ],
-  [
-    "\\mbfscrX",
-    "mathematical bold script capital x"
-  ],
-  [
-    "\\mbfscrY",
-    "mathematical bold script capital y"
-  ],
-  [
-    "\\mbfscrZ",
-    "mathematical bold script capital z"
-  ],
-  [
-    "\\mbfscra",
-    "mathematical bold script small a"
-  ],
-  [
-    "\\mbfscrb",
-    "mathematical bold script small b"
-  ],
-  [
-    "\\mbfscrc",
-    "mathematical bold script small c"
-  ],
-  [
-    "\\mbfscrd",
-    "mathematical bold script small d"
-  ],
-  [
-    "\\mbfscre",
-    "mathematical bold script small e"
-  ],
-  [
-    "\\mbfscrf",
-    "mathematical bold script small f"
-  ],
-  [
-    "\\mbfscrg",
-    "mathematical bold script small g"
-  ],
-  [
-    "\\mbfscrh",
-    "mathematical bold script small h"
-  ],
-  [
-    "\\mbfscri",
-    "mathematical bold script small i"
-  ],
-  [
-    "\\mbfscrj",
-    "mathematical bold script small j"
-  ],
-  [
-    "\\mbfscrk",
-    "mathematical bold script small k"
-  ],
-  [
-    "\\mbfscrl",
-    "mathematical bold script small l"
-  ],
-  [
-    "\\mbfscrm",
-    "mathematical bold script small m"
-  ],
-  [
-    "\\mbfscrn",
-    "mathematical bold script small n"
-  ],
-  [
-    "\\mbfscro",
-    "mathematical bold script small o"
-  ],
-  [
-    "\\mbfscrp",
-    "mathematical bold script small p"
-  ],
-  [
-    "\\mbfscrq",
-    "mathematical bold script small q"
-  ],
-  [
-    "\\mbfscrr",
-    "mathematical bold script small r"
-  ],
-  [
-    "\\mbfscrs",
-    "mathematical bold script small s"
-  ],
-  [
-    "\\mbfscrt",
-    "mathematical bold script small t"
-  ],
-  [
-    "\\mbfscru",
-    "mathematical bold script small u"
-  ],
-  [
-    "\\mbfscrv",
-    "mathematical bold script small v"
-  ],
-  [
-    "\\mbfscrw",
-    "mathematical bold script small w"
-  ],
-  [
-    "\\mbfscrx",
-    "mathematical bold script small x"
-  ],
-  [
-    "\\mbfscry",
-    "mathematical bold script small y"
-  ],
-  [
-    "\\mbfscrz",
-    "mathematical bold script small z"
-  ],
-  [
-    "\\mfrakA",
-    "mathematical fraktur capital a"
-  ],
-  [
-    "\\mfrakB",
-    "mathematical fraktur capital b"
-  ],
-  [
-    "\\mfrakD",
-    "mathematical fraktur capital d"
-  ],
-  [
-    "\\mfrakE",
-    "mathematical fraktur capital e"
-  ],
-  [
-    "\\mfrakF",
-    "mathematical fraktur capital f"
-  ],
-  [
-    "\\mfrakG",
-    "mathematical fraktur capital g"
-  ],
-  [
-    "\\mfrakJ",
-    "mathematical fraktur capital j"
-  ],
-  [
-    "\\mfrakK",
-    "mathematical fraktur capital k"
-  ],
-  [
-    "\\mfrakL",
-    "mathematical fraktur capital l"
-  ],
-  [
-    "\\mfrakM",
-    "mathematical fraktur capital m"
-  ],
-  [
-    "\\mfrakN",
-    "mathematical fraktur capital n"
-  ],
-  [
-    "\\mfrakO",
-    "mathematical fraktur capital o"
-  ],
-  [
-    "\\mfrakP",
-    "mathematical fraktur capital p"
-  ],
-  [
-    "\\mfrakQ",
-    "mathematical fraktur capital q"
-  ],
-  [
-    "\\mfrakS",
-    "mathematical fraktur capital s"
-  ],
-  [
-    "\\mfrakT",
-    "mathematical fraktur capital t"
-  ],
-  [
-    "\\mfrakU",
-    "mathematical fraktur capital u"
-  ],
-  [
-    "\\mfrakV",
-    "mathematical fraktur capital v"
-  ],
-  [
-    "\\mfrakW",
-    "mathematical fraktur capital w"
-  ],
-  [
-    "\\mfrakX",
-    "mathematical fraktur capital x"
-  ],
-  [
-    "\\mfrakY",
-    "mathematical fraktur capital y"
-  ],
-  [
-    "\\mfraka",
-    "mathematical fraktur small a"
-  ],
-  [
-    "\\mfrakb",
-    "mathematical fraktur small b"
-  ],
-  [
-    "\\mfrakc",
-    "mathematical fraktur small c"
-  ],
-  [
-    "\\mfrakd",
-    "mathematical fraktur small d"
-  ],
-  [
-    "\\mfrake",
-    "mathematical fraktur small e"
-  ],
-  [
-    "\\mfrakf",
-    "mathematical fraktur small f"
-  ],
-  [
-    "\\mfrakg",
-    "mathematical fraktur small g"
-  ],
-  [
-    "\\mfrakh",
-    "mathematical fraktur small h"
-  ],
-  [
-    "\\mfraki",
-    "mathematical fraktur small i"
-  ],
-  [
-    "\\mfrakj",
-    "mathematical fraktur small j"
-  ],
-  [
-    "\\mfrakk",
-    "mathematical fraktur small k"
-  ],
-  [
-    "\\mfrakl",
-    "mathematical fraktur small l"
-  ],
-  [
-    "\\mfrakm",
-    "mathematical fraktur small m"
-  ],
-  [
-    "\\mfrakn",
-    "mathematical fraktur small n"
-  ],
-  [
-    "\\mfrako",
-    "mathematical fraktur small o"
-  ],
-  [
-    "\\mfrakp",
-    "mathematical fraktur small p"
-  ],
-  [
-    "\\mfrakq",
-    "mathematical fraktur small q"
-  ],
-  [
-    "\\mfrakr",
-    "mathematical fraktur small r"
-  ],
-  [
-    "\\mfraks",
-    "mathematical fraktur small s"
-  ],
-  [
-    "\\mfrakt",
-    "mathematical fraktur small t"
-  ],
-  [
-    "\\mfraku",
-    "mathematical fraktur small u"
-  ],
-  [
-    "\\mfrakv",
-    "mathematical fraktur small v"
-  ],
-  [
-    "\\mfrakw",
-    "mathematical fraktur small w"
-  ],
-  [
-    "\\mfrakx",
-    "mathematical fraktur small x"
-  ],
-  [
-    "\\mfraky",
-    "mathematical fraktur small y"
-  ],
-  [
-    "\\mfrakz",
-    "mathematical fraktur small z"
-  ],
-  [
-    "\\BbbA",
-    "mathematical double-struck capital a"
-  ],
-  [
-    "\\BbbB",
-    "mathematical double-struck capital b"
-  ],
-  [
-    "\\BbbD",
-    "mathematical double-struck capital d"
-  ],
-  [
-    "\\BbbE",
-    "mathematical double-struck capital e"
-  ],
-  [
-    "\\BbbF",
-    "mathematical double-struck capital f"
-  ],
-  [
-    "\\BbbG",
-    "mathematical double-struck capital g"
-  ],
-  [
-    "\\BbbI",
-    "mathematical double-struck capital i"
-  ],
-  [
-    "\\BbbJ",
-    "mathematical double-struck capital j"
-  ],
-  [
-    "\\BbbK",
-    "mathematical double-struck capital k"
-  ],
-  [
-    "\\BbbL",
-    "mathematical double-struck capital l"
-  ],
-  [
-    "\\BbbM",
-    "mathematical double-struck capital m"
-  ],
-  [
-    "\\BbbO",
-    "mathematical double-struck capital o"
-  ],
-  [
-    "\\BbbS",
-    "mathematical double-struck capital s"
-  ],
-  [
-    "\\BbbT",
-    "mathematical double-struck capital t"
-  ],
-  [
-    "\\BbbU",
-    "mathematical double-struck capital u"
-  ],
-  [
-    "\\BbbV",
-    "mathematical double-struck capital v"
-  ],
-  [
-    "\\BbbW",
-    "mathematical double-struck capital w"
-  ],
-  [
-    "\\BbbX",
-    "mathematical double-struck capital x"
-  ],
-  [
-    "\\BbbY",
-    "mathematical double-struck capital y"
-  ],
-  [
-    "\\Bbba",
-    "mathematical double-struck small a"
-  ],
-  [
-    "\\Bbbb",
-    "mathematical double-struck small b"
-  ],
-  [
-    "\\Bbbc",
-    "mathematical double-struck small c"
-  ],
-  [
-    "\\Bbbd",
-    "mathematical double-struck small d"
-  ],
-  [
-    "\\Bbbe",
-    "mathematical double-struck small e"
-  ],
-  [
-    "\\Bbbf",
-    "mathematical double-struck small f"
-  ],
-  [
-    "\\Bbbg",
-    "mathematical double-struck small g"
-  ],
-  [
-    "\\Bbbh",
-    "mathematical double-struck small h"
-  ],
-  [
-    "\\Bbbi",
-    "mathematical double-struck small i"
-  ],
-  [
-    "\\Bbbj",
-    "mathematical double-struck small j"
-  ],
-  [
-    "\\Bbbk",
-    "mathematical double-struck small k"
-  ],
-  [
-    "\\Bbbl",
-    "mathematical double-struck small l"
-  ],
-  [
-    "\\Bbbm",
-    "mathematical double-struck small m"
-  ],
-  [
-    "\\Bbbn",
-    "mathematical double-struck small n"
-  ],
-  [
-    "\\Bbbo",
-    "mathematical double-struck small o"
-  ],
-  [
-    "\\Bbbp",
-    "mathematical double-struck small p"
-  ],
-  [
-    "\\Bbbq",
-    "mathematical double-struck small q"
-  ],
-  [
-    "\\Bbbr",
-    "mathematical double-struck small r"
-  ],
-  [
-    "\\Bbbs",
-    "mathematical double-struck small s"
-  ],
-  [
-    "\\Bbbt",
-    "mathematical double-struck small t"
-  ],
-  [
-    "\\Bbbu",
-    "mathematical double-struck small u"
-  ],
-  [
-    "\\Bbbv",
-    "mathematical double-struck small v"
-  ],
-  [
-    "\\Bbbw",
-    "mathematical double-struck small w"
-  ],
-  [
-    "\\Bbbx",
-    "mathematical double-struck small x"
-  ],
-  [
-    "\\Bbby",
-    "mathematical double-struck small y"
-  ],
-  [
-    "\\Bbbz",
-    "mathematical double-struck small z"
-  ],
-  [
-    "\\mbffrakA",
-    "mathematical bold fraktur capital a"
-  ],
-  [
-    "\\mbffrakB",
-    "mathematical bold fraktur capital b"
-  ],
-  [
-    "\\mbffrakC",
-    "mathematical bold fraktur capital c"
-  ],
-  [
-    "\\mbffrakD",
-    "mathematical bold fraktur capital d"
-  ],
-  [
-    "\\mbffrakE",
-    "mathematical bold fraktur capital e"
-  ],
-  [
-    "\\mbffrakF",
-    "mathematical bold fraktur capital f"
-  ],
-  [
-    "\\mbffrakG",
-    "mathematical bold fraktur capital g"
-  ],
-  [
-    "\\mbffrakH",
-    "mathematical bold fraktur capital h"
-  ],
-  [
-    "\\mbffrakI",
-    "mathematical bold fraktur capital i"
-  ],
-  [
-    "\\mbffrakJ",
-    "mathematical bold fraktur capital j"
-  ],
-  [
-    "\\mbffrakK",
-    "mathematical bold fraktur capital k"
-  ],
-  [
-    "\\mbffrakL",
-    "mathematical bold fraktur capital l"
-  ],
-  [
-    "\\mbffrakM",
-    "mathematical bold fraktur capital m"
-  ],
-  [
-    "\\mbffrakN",
-    "mathematical bold fraktur capital n"
-  ],
-  [
-    "\\mbffrakO",
-    "mathematical bold fraktur capital o"
-  ],
-  [
-    "\\mbffrakP",
-    "mathematical bold fraktur capital p"
-  ],
-  [
-    "\\mbffrakQ",
-    "mathematical bold fraktur capital q"
-  ],
-  [
-    "\\mbffrakR",
-    "mathematical bold fraktur capital r"
-  ],
-  [
-    "\\mbffrakS",
-    "mathematical bold fraktur capital s"
-  ],
-  [
-    "\\mbffrakT",
-    "mathematical bold fraktur capital t"
-  ],
-  [
-    "\\mbffrakU",
-    "mathematical bold fraktur capital u"
-  ],
-  [
-    "\\mbffrakV",
-    "mathematical bold fraktur capital v"
-  ],
-  [
-    "\\mbffrakW",
-    "mathematical bold fraktur capital w"
-  ],
-  [
-    "\\mbffrakX",
-    "mathematical bold fraktur capital x"
-  ],
-  [
-    "\\mbffrakY",
-    "mathematical bold fraktur capital y"
-  ],
-  [
-    "\\mbffrakZ",
-    "mathematical bold fraktur capital z"
-  ],
-  [
-    "\\mbffraka",
-    "mathematical bold fraktur small a"
-  ],
-  [
-    "\\mbffrakb",
-    "mathematical bold fraktur small b"
-  ],
-  [
-    "\\mbffrakc",
-    "mathematical bold fraktur small c"
-  ],
-  [
-    "\\mbffrakd",
-    "mathematical bold fraktur small d"
-  ],
-  [
-    "\\mbffrake",
-    "mathematical bold fraktur small e"
-  ],
-  [
-    "\\mbffrakf",
-    "mathematical bold fraktur small f"
-  ],
-  [
-    "\\mbffrakg",
-    "mathematical bold fraktur small g"
-  ],
-  [
-    "\\mbffrakh",
-    "mathematical bold fraktur small h"
-  ],
-  [
-    "\\mbffraki",
-    "mathematical bold fraktur small i"
-  ],
-  [
-    "\\mbffrakj",
-    "mathematical bold fraktur small j"
-  ],
-  [
-    "\\mbffrakk",
-    "mathematical bold fraktur small k"
-  ],
-  [
-    "\\mbffrakl",
-    "mathematical bold fraktur small l"
-  ],
-  [
-    "\\mbffrakm",
-    "mathematical bold fraktur small m"
-  ],
-  [
-    "\\mbffrakn",
-    "mathematical bold fraktur small n"
-  ],
-  [
-    "\\mbffrako",
-    "mathematical bold fraktur small o"
-  ],
-  [
-    "\\mbffrakp",
-    "mathematical bold fraktur small p"
-  ],
-  [
-    "\\mbffrakq",
-    "mathematical bold fraktur small q"
-  ],
-  [
-    "\\mbffrakr",
-    "mathematical bold fraktur small r"
-  ],
-  [
-    "\\mbffraks",
-    "mathematical bold fraktur small s"
-  ],
-  [
-    "\\mbffrakt",
-    "mathematical bold fraktur small t"
-  ],
-  [
-    "\\mbffraku",
-    "mathematical bold fraktur small u"
-  ],
-  [
-    "\\mbffrakv",
-    "mathematical bold fraktur small v"
-  ],
-  [
-    "\\mbffrakw",
-    "mathematical bold fraktur small w"
-  ],
-  [
-    "\\mbffrakx",
-    "mathematical bold fraktur small x"
-  ],
-  [
-    "\\mbffraky",
-    "mathematical bold fraktur small y"
-  ],
-  [
-    "\\mbffrakz",
-    "mathematical bold fraktur small z"
-  ],
-  [
-    "\\msansA",
-    "mathematical sans-serif capital a"
-  ],
-  [
-    "\\msansB",
-    "mathematical sans-serif capital b"
-  ],
-  [
-    "\\msansC",
-    "mathematical sans-serif capital c"
-  ],
-  [
-    "\\msansD",
-    "mathematical sans-serif capital d"
-  ],
-  [
-    "\\msansE",
-    "mathematical sans-serif capital e"
-  ],
-  [
-    "\\msansF",
-    "mathematical sans-serif capital f"
-  ],
-  [
-    "\\msansG",
-    "mathematical sans-serif capital g"
-  ],
-  [
-    "\\msansH",
-    "mathematical sans-serif capital h"
-  ],
-  [
-    "\\msansI",
-    "mathematical sans-serif capital i"
-  ],
-  [
-    "\\msansJ",
-    "mathematical sans-serif capital j"
-  ],
-  [
-    "\\msansK",
-    "mathematical sans-serif capital k"
-  ],
-  [
-    "\\msansL",
-    "mathematical sans-serif capital l"
-  ],
-  [
-    "\\msansM",
-    "mathematical sans-serif capital m"
-  ],
-  [
-    "\\msansN",
-    "mathematical sans-serif capital n"
-  ],
-  [
-    "\\msansO",
-    "mathematical sans-serif capital o"
-  ],
-  [
-    "\\msansP",
-    "mathematical sans-serif capital p"
-  ],
-  [
-    "\\msansQ",
-    "mathematical sans-serif capital q"
-  ],
-  [
-    "\\msansR",
-    "mathematical sans-serif capital r"
-  ],
-  [
-    "\\msansS",
-    "mathematical sans-serif capital s"
-  ],
-  [
-    "\\msansT",
-    "mathematical sans-serif capital t"
-  ],
-  [
-    "\\msansU",
-    "mathematical sans-serif capital u"
-  ],
-  [
-    "\\msansV",
-    "mathematical sans-serif capital v"
-  ],
-  [
-    "\\msansW",
-    "mathematical sans-serif capital w"
-  ],
-  [
-    "\\msansX",
-    "mathematical sans-serif capital x"
-  ],
-  [
-    "\\msansY",
-    "mathematical sans-serif capital y"
-  ],
-  [
-    "\\msansZ",
-    "mathematical sans-serif capital z"
-  ],
-  [
-    "\\msansa",
-    "mathematical sans-serif small a"
-  ],
-  [
-    "\\msansb",
-    "mathematical sans-serif small b"
-  ],
-  [
-    "\\msansc",
-    "mathematical sans-serif small c"
-  ],
-  [
-    "\\msansd",
-    "mathematical sans-serif small d"
-  ],
-  [
-    "\\msanse",
-    "mathematical sans-serif small e"
-  ],
-  [
-    "\\msansf",
-    "mathematical sans-serif small f"
-  ],
-  [
-    "\\msansg",
-    "mathematical sans-serif small g"
-  ],
-  [
-    "\\msansh",
-    "mathematical sans-serif small h"
-  ],
-  [
-    "\\msansi",
-    "mathematical sans-serif small i"
-  ],
-  [
-    "\\msansj",
-    "mathematical sans-serif small j"
-  ],
-  [
-    "\\msansk",
-    "mathematical sans-serif small k"
-  ],
-  [
-    "\\msansl",
-    "mathematical sans-serif small l"
-  ],
-  [
-    "\\msansm",
-    "mathematical sans-serif small m"
-  ],
-  [
-    "\\msansn",
-    "mathematical sans-serif small n"
-  ],
-  [
-    "\\msanso",
-    "mathematical sans-serif small o"
-  ],
-  [
-    "\\msansp",
-    "mathematical sans-serif small p"
-  ],
-  [
-    "\\msansq",
-    "mathematical sans-serif small q"
-  ],
-  [
-    "\\msansr",
-    "mathematical sans-serif small r"
-  ],
-  [
-    "\\msanss",
-    "mathematical sans-serif small s"
-  ],
-  [
-    "\\msanst",
-    "mathematical sans-serif small t"
-  ],
-  [
-    "\\msansu",
-    "mathematical sans-serif small u"
-  ],
-  [
-    "\\msansv",
-    "mathematical sans-serif small v"
-  ],
-  [
-    "\\msansw",
-    "mathematical sans-serif small w"
-  ],
-  [
-    "\\msansx",
-    "mathematical sans-serif small x"
-  ],
-  [
-    "\\msansy",
-    "mathematical sans-serif small y"
-  ],
-  [
-    "\\msansz",
-    "mathematical sans-serif small z"
-  ],
-  [
-    "\\mbfsansA",
-    "mathematical sans-serif bold capital a"
-  ],
-  [
-    "\\mbfsansB",
-    "mathematical sans-serif bold capital b"
-  ],
-  [
-    "\\mbfsansC",
-    "mathematical sans-serif bold capital c"
-  ],
-  [
-    "\\mbfsansD",
-    "mathematical sans-serif bold capital d"
-  ],
-  [
-    "\\mbfsansE",
-    "mathematical sans-serif bold capital e"
-  ],
-  [
-    "\\mbfsansF",
-    "mathematical sans-serif bold capital f"
-  ],
-  [
-    "\\mbfsansG",
-    "mathematical sans-serif bold capital g"
-  ],
-  [
-    "\\mbfsansH",
-    "mathematical sans-serif bold capital h"
-  ],
-  [
-    "\\mbfsansI",
-    "mathematical sans-serif bold capital i"
-  ],
-  [
-    "\\mbfsansJ",
-    "mathematical sans-serif bold capital j"
-  ],
-  [
-    "\\mbfsansK",
-    "mathematical sans-serif bold capital k"
-  ],
-  [
-    "\\mbfsansL",
-    "mathematical sans-serif bold capital l"
-  ],
-  [
-    "\\mbfsansM",
-    "mathematical sans-serif bold capital m"
-  ],
-  [
-    "\\mbfsansN",
-    "mathematical sans-serif bold capital n"
-  ],
-  [
-    "\\mbfsansO",
-    "mathematical sans-serif bold capital o"
-  ],
-  [
-    "\\mbfsansP",
-    "mathematical sans-serif bold capital p"
-  ],
-  [
-    "\\mbfsansQ",
-    "mathematical sans-serif bold capital q"
-  ],
-  [
-    "\\mbfsansR",
-    "mathematical sans-serif bold capital r"
-  ],
-  [
-    "\\mbfsansS",
-    "mathematical sans-serif bold capital s"
-  ],
-  [
-    "\\mbfsansT",
-    "mathematical sans-serif bold capital t"
-  ],
-  [
-    "\\mbfsansU",
-    "mathematical sans-serif bold capital u"
-  ],
-  [
-    "\\mbfsansV",
-    "mathematical sans-serif bold capital v"
-  ],
-  [
-    "\\mbfsansW",
-    "mathematical sans-serif bold capital w"
-  ],
-  [
-    "\\mbfsansX",
-    "mathematical sans-serif bold capital x"
-  ],
-  [
-    "\\mbfsansY",
-    "mathematical sans-serif bold capital y"
-  ],
-  [
-    "\\mbfsansZ",
-    "mathematical sans-serif bold capital z"
-  ],
-  [
-    "\\mbfsansa",
-    "mathematical sans-serif bold small a"
-  ],
-  [
-    "\\mbfsansb",
-    "mathematical sans-serif bold small b"
-  ],
-  [
-    "\\mbfsansc",
-    "mathematical sans-serif bold small c"
-  ],
-  [
-    "\\mbfsansd",
-    "mathematical sans-serif bold small d"
-  ],
-  [
-    "\\mbfsanse",
-    "mathematical sans-serif bold small e"
-  ],
-  [
-    "\\mbfsansf",
-    "mathematical sans-serif bold small f"
-  ],
-  [
-    "\\mbfsansg",
-    "mathematical sans-serif bold small g"
-  ],
-  [
-    "\\mbfsansh",
-    "mathematical sans-serif bold small h"
-  ],
-  [
-    "\\mbfsansi",
-    "mathematical sans-serif bold small i"
-  ],
-  [
-    "\\mbfsansj",
-    "mathematical sans-serif bold small j"
-  ],
-  [
-    "\\mbfsansk",
-    "mathematical sans-serif bold small k"
-  ],
-  [
-    "\\mbfsansl",
-    "mathematical sans-serif bold small l"
-  ],
-  [
-    "\\mbfsansm",
-    "mathematical sans-serif bold small m"
-  ],
-  [
-    "\\mbfsansn",
-    "mathematical sans-serif bold small n"
-  ],
-  [
-    "\\mbfsanso",
-    "mathematical sans-serif bold small o"
-  ],
-  [
-    "\\mbfsansp",
-    "mathematical sans-serif bold small p"
-  ],
-  [
-    "\\mbfsansq",
-    "mathematical sans-serif bold small q"
-  ],
-  [
-    "\\mbfsansr",
-    "mathematical sans-serif bold small r"
-  ],
-  [
-    "\\mbfsanss",
-    "mathematical sans-serif bold small s"
-  ],
-  [
-    "\\mbfsanst",
-    "mathematical sans-serif bold small t"
-  ],
-  [
-    "\\mbfsansu",
-    "mathematical sans-serif bold small u"
-  ],
-  [
-    "\\mbfsansv",
-    "mathematical sans-serif bold small v"
-  ],
-  [
-    "\\mbfsansw",
-    "mathematical sans-serif bold small w"
-  ],
-  [
-    "\\mbfsansx",
-    "mathematical sans-serif bold small x"
-  ],
-  [
-    "\\mbfsansy",
-    "mathematical sans-serif bold small y"
-  ],
-  [
-    "\\mbfsansz",
-    "mathematical sans-serif bold small z"
-  ],
-  [
-    "\\mitsansA",
-    "mathematical sans-serif italic capital a"
-  ],
-  [
-    "\\mitsansB",
-    "mathematical sans-serif italic capital b"
-  ],
-  [
-    "\\mitsansC",
-    "mathematical sans-serif italic capital c"
-  ],
-  [
-    "\\mitsansD",
-    "mathematical sans-serif italic capital d"
-  ],
-  [
-    "\\mitsansE",
-    "mathematical sans-serif italic capital e"
-  ],
-  [
-    "\\mitsansF",
-    "mathematical sans-serif italic capital f"
-  ],
-  [
-    "\\mitsansG",
-    "mathematical sans-serif italic capital g"
-  ],
-  [
-    "\\mitsansH",
-    "mathematical sans-serif italic capital h"
-  ],
-  [
-    "\\mitsansI",
-    "mathematical sans-serif italic capital i"
-  ],
-  [
-    "\\mitsansJ",
-    "mathematical sans-serif italic capital j"
-  ],
-  [
-    "\\mitsansK",
-    "mathematical sans-serif italic capital k"
-  ],
-  [
-    "\\mitsansL",
-    "mathematical sans-serif italic capital l"
-  ],
-  [
-    "\\mitsansM",
-    "mathematical sans-serif italic capital m"
-  ],
-  [
-    "\\mitsansN",
-    "mathematical sans-serif italic capital n"
-  ],
-  [
-    "\\mitsansO",
-    "mathematical sans-serif italic capital o"
-  ],
-  [
-    "\\mitsansP",
-    "mathematical sans-serif italic capital p"
-  ],
-  [
-    "\\mitsansQ",
-    "mathematical sans-serif italic capital q"
-  ],
-  [
-    "\\mitsansR",
-    "mathematical sans-serif italic capital r"
-  ],
-  [
-    "\\mitsansS",
-    "mathematical sans-serif italic capital s"
-  ],
-  [
-    "\\mitsansT",
-    "mathematical sans-serif italic capital t"
-  ],
-  [
-    "\\mitsansU",
-    "mathematical sans-serif italic capital u"
-  ],
-  [
-    "\\mitsansV",
-    "mathematical sans-serif italic capital v"
-  ],
-  [
-    "\\mitsansW",
-    "mathematical sans-serif italic capital w"
-  ],
-  [
-    "\\mitsansX",
-    "mathematical sans-serif italic capital x"
-  ],
-  [
-    "\\mitsansY",
-    "mathematical sans-serif italic capital y"
-  ],
-  [
-    "\\mitsansZ",
-    "mathematical sans-serif italic capital z"
-  ],
-  [
-    "\\mitsansa",
-    "mathematical sans-serif italic small a"
-  ],
-  [
-    "\\mitsansb",
-    "mathematical sans-serif italic small b"
-  ],
-  [
-    "\\mitsansc",
-    "mathematical sans-serif italic small c"
-  ],
-  [
-    "\\mitsansd",
-    "mathematical sans-serif italic small d"
-  ],
-  [
-    "\\mitsanse",
-    "mathematical sans-serif italic small e"
-  ],
-  [
-    "\\mitsansf",
-    "mathematical sans-serif italic small f"
-  ],
-  [
-    "\\mitsansg",
-    "mathematical sans-serif italic small g"
-  ],
-  [
-    "\\mitsansh",
-    "mathematical sans-serif italic small h"
-  ],
-  [
-    "\\mitsansi",
-    "mathematical sans-serif italic small i"
-  ],
-  [
-    "\\mitsansj",
-    "mathematical sans-serif italic small j"
-  ],
-  [
-    "\\mitsansk",
-    "mathematical sans-serif italic small k"
-  ],
-  [
-    "\\mitsansl",
-    "mathematical sans-serif italic small l"
-  ],
-  [
-    "\\mitsansm",
-    "mathematical sans-serif italic small m"
-  ],
-  [
-    "\\mitsansn",
-    "mathematical sans-serif italic small n"
-  ],
-  [
-    "\\mitsanso",
-    "mathematical sans-serif italic small o"
-  ],
-  [
-    "\\mitsansp",
-    "mathematical sans-serif italic small p"
-  ],
-  [
-    "\\mitsansq",
-    "mathematical sans-serif italic small q"
-  ],
-  [
-    "\\mitsansr",
-    "mathematical sans-serif italic small r"
-  ],
-  [
-    "\\mitsanss",
-    "mathematical sans-serif italic small s"
-  ],
-  [
-    "\\mitsanst",
-    "mathematical sans-serif italic small t"
-  ],
-  [
-    "\\mitsansu",
-    "mathematical sans-serif italic small u"
-  ],
-  [
-    "\\mitsansv",
-    "mathematical sans-serif italic small v"
-  ],
-  [
-    "\\mitsansw",
-    "mathematical sans-serif italic small w"
-  ],
-  [
-    "\\mitsansx",
-    "mathematical sans-serif italic small x"
-  ],
-  [
-    "\\mitsansy",
-    "mathematical sans-serif italic small y"
-  ],
-  [
-    "\\mitsansz",
-    "mathematical sans-serif italic small z"
-  ],
-  [
-    "\\mbfitsansA",
-    "mathematical sans-serif bold italic capital a"
-  ],
-  [
-    "\\mbfitsansB",
-    "mathematical sans-serif bold italic capital b"
-  ],
-  [
-    "\\mbfitsansC",
-    "mathematical sans-serif bold italic capital c"
-  ],
-  [
-    "\\mbfitsansD",
-    "mathematical sans-serif bold italic capital d"
-  ],
-  [
-    "\\mbfitsansE",
-    "mathematical sans-serif bold italic capital e"
-  ],
-  [
-    "\\mbfitsansF",
-    "mathematical sans-serif bold italic capital f"
-  ],
-  [
-    "\\mbfitsansG",
-    "mathematical sans-serif bold italic capital g"
-  ],
-  [
-    "\\mbfitsansH",
-    "mathematical sans-serif bold italic capital h"
-  ],
-  [
-    "\\mbfitsansI",
-    "mathematical sans-serif bold italic capital i"
-  ],
-  [
-    "\\mbfitsansJ",
-    "mathematical sans-serif bold italic capital j"
-  ],
-  [
-    "\\mbfitsansK",
-    "mathematical sans-serif bold italic capital k"
-  ],
-  [
-    "\\mbfitsansL",
-    "mathematical sans-serif bold italic capital l"
-  ],
-  [
-    "\\mbfitsansM",
-    "mathematical sans-serif bold italic capital m"
-  ],
-  [
-    "\\mbfitsansN",
-    "mathematical sans-serif bold italic capital n"
-  ],
-  [
-    "\\mbfitsansO",
-    "mathematical sans-serif bold italic capital o"
-  ],
-  [
-    "\\mbfitsansP",
-    "mathematical sans-serif bold italic capital p"
-  ],
-  [
-    "\\mbfitsansQ",
-    "mathematical sans-serif bold italic capital q"
-  ],
-  [
-    "\\mbfitsansR",
-    "mathematical sans-serif bold italic capital r"
-  ],
-  [
-    "\\mbfitsansS",
-    "mathematical sans-serif bold italic capital s"
-  ],
-  [
-    "\\mbfitsansT",
-    "mathematical sans-serif bold italic capital t"
-  ],
-  [
-    "\\mbfitsansU",
-    "mathematical sans-serif bold italic capital u"
-  ],
-  [
-    "\\mbfitsansV",
-    "mathematical sans-serif bold italic capital v"
-  ],
-  [
-    "\\mbfitsansW",
-    "mathematical sans-serif bold italic capital w"
-  ],
-  [
-    "\\mbfitsansX",
-    "mathematical sans-serif bold italic capital x"
-  ],
-  [
-    "\\mbfitsansY",
-    "mathematical sans-serif bold italic capital y"
-  ],
-  [
-    "\\mbfitsansZ",
-    "mathematical sans-serif bold italic capital z"
-  ],
-  [
-    "\\mbfitsansa",
-    "mathematical sans-serif bold italic small a"
-  ],
-  [
-    "\\mbfitsansb",
-    "mathematical sans-serif bold italic small b"
-  ],
-  [
-    "\\mbfitsansc",
-    "mathematical sans-serif bold italic small c"
-  ],
-  [
-    "\\mbfitsansd",
-    "mathematical sans-serif bold italic small d"
-  ],
-  [
-    "\\mbfitsanse",
-    "mathematical sans-serif bold italic small e"
-  ],
-  [
-    "\\mbfitsansf",
-    "mathematical sans-serif bold italic small f"
-  ],
-  [
-    "\\mbfitsansg",
-    "mathematical sans-serif bold italic small g"
-  ],
-  [
-    "\\mbfitsansh",
-    "mathematical sans-serif bold italic small h"
-  ],
-  [
-    "\\mbfitsansi",
-    "mathematical sans-serif bold italic small i"
-  ],
-  [
-    "\\mbfitsansj",
-    "mathematical sans-serif bold italic small j"
-  ],
-  [
-    "\\mbfitsansk",
-    "mathematical sans-serif bold italic small k"
-  ],
-  [
-    "\\mbfitsansl",
-    "mathematical sans-serif bold italic small l"
-  ],
-  [
-    "\\mbfitsansm",
-    "mathematical sans-serif bold italic small m"
-  ],
-  [
-    "\\mbfitsansn",
-    "mathematical sans-serif bold italic small n"
-  ],
-  [
-    "\\mbfitsanso",
-    "mathematical sans-serif bold italic small o"
-  ],
-  [
-    "\\mbfitsansp",
-    "mathematical sans-serif bold italic small p"
-  ],
-  [
-    "\\mbfitsansq",
-    "mathematical sans-serif bold italic small q"
-  ],
-  [
-    "\\mbfitsansr",
-    "mathematical sans-serif bold italic small r"
-  ],
-  [
-    "\\mbfitsanss",
-    "mathematical sans-serif bold italic small s"
-  ],
-  [
-    "\\mbfitsanst",
-    "mathematical sans-serif bold italic small t"
-  ],
-  [
-    "\\mbfitsansu",
-    "mathematical sans-serif bold italic small u"
-  ],
-  [
-    "\\mbfitsansv",
-    "mathematical sans-serif bold italic small v"
-  ],
-  [
-    "\\mbfitsansw",
-    "mathematical sans-serif bold italic small w"
-  ],
-  [
-    "\\mbfitsansx",
-    "mathematical sans-serif bold italic small x"
-  ],
-  [
-    "\\mbfitsansy",
-    "mathematical sans-serif bold italic small y"
-  ],
-  [
-    "\\mbfitsansz",
-    "mathematical sans-serif bold italic small z"
-  ],
-  [
-    "\\mttA",
-    "mathematical monospace capital a"
-  ],
-  [
-    "\\mttB",
-    "mathematical monospace capital b"
-  ],
-  [
-    "\\mttC",
-    "mathematical monospace capital c"
-  ],
-  [
-    "\\mttD",
-    "mathematical monospace capital d"
-  ],
-  [
-    "\\mttE",
-    "mathematical monospace capital e"
-  ],
-  [
-    "\\mttF",
-    "mathematical monospace capital f"
-  ],
-  [
-    "\\mttG",
-    "mathematical monospace capital g"
-  ],
-  [
-    "\\mttH",
-    "mathematical monospace capital h"
-  ],
-  [
-    "\\mttI",
-    "mathematical monospace capital i"
-  ],
-  [
-    "\\mttJ",
-    "mathematical monospace capital j"
-  ],
-  [
-    "\\mttK",
-    "mathematical monospace capital k"
-  ],
-  [
-    "\\mttL",
-    "mathematical monospace capital l"
-  ],
-  [
-    "\\mttM",
-    "mathematical monospace capital m"
-  ],
-  [
-    "\\mttN",
-    "mathematical monospace capital n"
-  ],
-  [
-    "\\mttO",
-    "mathematical monospace capital o"
-  ],
-  [
-    "\\mttP",
-    "mathematical monospace capital p"
-  ],
-  [
-    "\\mttQ",
-    "mathematical monospace capital q"
-  ],
-  [
-    "\\mttR",
-    "mathematical monospace capital r"
-  ],
-  [
-    "\\mttS",
-    "mathematical monospace capital s"
-  ],
-  [
-    "\\mttT",
-    "mathematical monospace capital t"
-  ],
-  [
-    "\\mttU",
-    "mathematical monospace capital u"
-  ],
-  [
-    "\\mttV",
-    "mathematical monospace capital v"
-  ],
-  [
-    "\\mttW",
-    "mathematical monospace capital w"
-  ],
-  [
-    "\\mttX",
-    "mathematical monospace capital x"
-  ],
-  [
-    "\\mttY",
-    "mathematical monospace capital y"
-  ],
-  [
-    "\\mttZ",
-    "mathematical monospace capital z"
-  ],
-  [
-    "\\mtta",
-    "mathematical monospace small a"
-  ],
-  [
-    "\\mttb",
-    "mathematical monospace small b"
-  ],
-  [
-    "\\mttc",
-    "mathematical monospace small c"
-  ],
-  [
-    "\\mttd",
-    "mathematical monospace small d"
-  ],
-  [
-    "\\mtte",
-    "mathematical monospace small e"
-  ],
-  [
-    "\\mttf",
-    "mathematical monospace small f"
-  ],
-  [
-    "\\mttg",
-    "mathematical monospace small g"
-  ],
-  [
-    "\\mtth",
-    "mathematical monospace small h"
-  ],
-  [
-    "\\mtti",
-    "mathematical monospace small i"
-  ],
-  [
-    "\\mttj",
-    "mathematical monospace small j"
-  ],
-  [
-    "\\mttk",
-    "mathematical monospace small k"
-  ],
-  [
-    "\\mttl",
-    "mathematical monospace small l"
-  ],
-  [
-    "\\mttm",
-    "mathematical monospace small m"
-  ],
-  [
-    "\\mttn",
-    "mathematical monospace small n"
-  ],
-  [
-    "\\mtto",
-    "mathematical monospace small o"
-  ],
-  [
-    "\\mttp",
-    "mathematical monospace small p"
-  ],
-  [
-    "\\mttq",
-    "mathematical monospace small q"
-  ],
-  [
-    "\\mttr",
-    "mathematical monospace small r"
-  ],
-  [
-    "\\mtts",
-    "mathematical monospace small s"
-  ],
-  [
-    "\\mttt",
-    "mathematical monospace small t"
-  ],
-  [
-    "\\mttu",
-    "mathematical monospace small u"
-  ],
-  [
-    "\\mttv",
-    "mathematical monospace small v"
-  ],
-  [
-    "\\mttw",
-    "mathematical monospace small w"
-  ],
-  [
-    "\\mttx",
-    "mathematical monospace small x"
-  ],
-  [
-    "\\mtty",
-    "mathematical monospace small y"
-  ],
-  [
-    "\\mttz",
-    "mathematical monospace small z"
+    "÷ divide sign"
   ],
   [
     "\\imath",
-    "mathematical italic small dotless i"
+    "ı imath"
+  ],
+  [
+    "\\Zbar",
+    "ƶ  impedance"
   ],
   [
     "\\jmath",
-    "mathematical italic small dotless j"
+    "ȷ jmath"
+  ],
+  [
+    "\\grave",
+    " ̀ grave accent"
+  ],
+  [
+    "\\acute",
+    " ́ acute accent"
+  ],
+  [
+    "\\hat",
+    " ̂ # \\widehat (amssymb), circumflex accent"
+  ],
+  [
+    "\\tilde",
+    " ̃ # \\widetilde (yhmath, fourier), tilde"
+  ],
+  [
+    "\\bar",
+    " ̄ macron"
+  ],
+  [
+    "\\overline",
+    " ̅ overbar embellishment"
+  ],
+  [
+    "\\breve",
+    " ̆ breve"
+  ],
+  [
+    "\\dot",
+    " ̇ = \\dot (wrisym), dot above"
+  ],
+  [
+    "\\ddot",
+    " ̈ = \\ddot (wrisym), dieresis"
+  ],
+  [
+    "\\ovhook",
+    " ̉  combining hook above"
+  ],
+  [
+    "\\mathring",
+    " ̊ = \\ring (yhmath), ring"
+  ],
+  [
+    "\\check",
+    " ̌ caron"
+  ],
+  [
+    "\\candra",
+    " ̐  candrabindu (non-spacing)"
+  ],
+  [
+    "\\oturnedcomma",
+    " ̒  combining turned comma above"
+  ],
+  [
+    "\\ocommatopright",
+    " ̕  combining comma above right"
+  ],
+  [
+    "\\droang",
+    " ̚  left angle above (non-spacing)"
+  ],
+  [
+    "\\utilde",
+    " ̰ under tilde accent (multiple characters and non-spacing)"
+  ],
+  [
+    "\\underbar",
+    " ̱ combining macron below"
+  ],
+  [
+    "\\underline",
+    " ̲ combining low line"
+  ],
+  [
+    "\\not",
+    " ̸ combining long solidus overlay"
+  ],
+  [
+    "\\upAlpha",
+    "α  capital alpha, greek"
+  ],
+  [
+    "\\upBeta",
+    "β  capital beta, greek"
+  ],
+  [
+    "\\Gamma",
+    "γ = \\gamma (-slantedgreek), = \\mathrm{\\gamma}, capital gamma, greek"
+  ],
+  [
+    "\\Delta",
+    "δ = \\delta (-slantedgreek), = \\mathrm{\\delta}, capital delta, greek"
+  ],
+  [
+    "\\upEpsilon",
+    "ε  capital epsilon, greek"
+  ],
+  [
+    "\\upZeta",
+    "ζ  capital zeta, greek"
+  ],
+  [
+    "\\upEta",
+    "η  capital eta, greek"
+  ],
+  [
+    "\\Theta",
+    "θ = \\theta (-slantedgreek), = \\mathrm{\\theta}, capital theta, greek"
+  ],
+  [
+    "\\upIota",
+    "ι  capital iota, greek"
+  ],
+  [
+    "\\upKappa",
+    "κ  capital kappa, greek"
+  ],
+  [
+    "\\Lambda",
+    "λ = \\lambda (-slantedgreek), = \\mathrm{\\lambda}, capital lambda, greek"
+  ],
+  [
+    "\\upMu",
+    "μ  capital mu, greek"
+  ],
+  [
+    "\\upNu",
+    "ν  capital nu, greek"
+  ],
+  [
+    "\\Xi",
+    "ξ = \\xi (-slantedgreek), = \\mathrm{\\xi}, capital xi, greek"
+  ],
+  [
+    "\\upOmicron",
+    "ο  capital omicron, greek"
+  ],
+  [
+    "\\Pi",
+    "π = \\pi (-slantedgreek), = \\mathrm{\\pi}, capital pi, greek"
+  ],
+  [
+    "\\upRho",
+    "ρ  capital rho, greek"
+  ],
+  [
+    "\\Sigma",
+    "σ = \\sigma (-slantedgreek), = \\mathrm{\\sigma}, capital sigma, greek"
+  ],
+  [
+    "\\upTau",
+    "τ  capital tau, greek"
+  ],
+  [
+    "\\Upsilon",
+    "υ = \\upsilon (-slantedgreek), = \\mathrm{\\upsilon}, capital upsilon, greek"
+  ],
+  [
+    "\\Phi",
+    "φ = \\phi (-slantedgreek), = \\mathrm{\\phi}, capital phi, greek"
+  ],
+  [
+    "\\upChi",
+    "χ  capital chi, greek"
+  ],
+  [
+    "\\Psi",
+    "ψ = \\psi (-slantedgreek), = \\mathrm{\\psi}, capital psi, greek"
+  ],
+  [
+    "\\Omega",
+    "ω = \\omega (-slantedgreek), = \\mathrm{\\omega}, capital omega, greek"
+  ],
+  [
+    "\\alpha",
+    "α = \\mathrm{\\alpha} (omlmathrm), = \\alphaup (kpfonts mathdesign), = \\upalpha (upgreek), alpha, greek"
+  ],
+  [
+    "\\beta",
+    "β = \\mathrm{\\beta} (omlmathrm), = \\betaup (kpfonts mathdesign), = \\upbeta (upgreek), beta, greek"
+  ],
+  [
+    "\\gamma",
+    "γ = \\mathrm{\\gamma} (omlmathrm), = \\gammaup (kpfonts mathdesign), = \\upgamma (upgreek), gamma, greek"
+  ],
+  [
+    "\\delta",
+    "δ = \\mathrm{\\delta} (omlmathrm), = \\deltaup (kpfonts mathdesign), = \\updelta (upgreek), delta, greek"
+  ],
+  [
+    "\\varepsilon",
+    "ε = \\mathrm{\\varepsilon} (omlmathrm), = \\varepsilonup (kpfonts mathdesign), = \\upepsilon (upgreek), rounded epsilon, greek"
+  ],
+  [
+    "\\zeta",
+    "ζ = \\mathrm{\\zeta} (omlmathrm), = \\zetaup (kpfonts mathdesign), = \\upzeta (upgreek), zeta, greek"
+  ],
+  [
+    "\\eta",
+    "η = \\mathrm{\\eta} (omlmathrm), = \\etaup (kpfonts mathdesign), = \\upeta (upgreek), eta, greek"
+  ],
+  [
+    "\\theta",
+    "θ = \\mathrm{\\theta} (omlmathrm), = \\thetaup (kpfonts mathdesign), straight theta, = \\uptheta (upgreek), theta, greek"
+  ],
+  [
+    "\\iota",
+    "ι = \\mathrm{\\iota} (omlmathrm), = \\iotaup (kpfonts mathdesign), = \\upiota (upgreek), iota, greek"
+  ],
+  [
+    "\\kappa",
+    "κ = \\mathrm{\\kappa} (omlmathrm), = \\kappaup (kpfonts mathdesign), = \\upkappa (upgreek), kappa, greek"
+  ],
+  [
+    "\\lambda",
+    "λ = \\mathrm{\\lambda} (omlmathrm), = \\lambdaup (kpfonts mathdesign), = \\uplambda (upgreek), lambda, greek"
+  ],
+  [
+    "\\mu",
+    "μ = \\mathrm{\\mu} (omlmathrm), = \\muup (kpfonts mathdesign), = \\upmu (upgreek), mu, greek"
+  ],
+  [
+    "\\nu",
+    "ν = \\mathrm{\\nu} (omlmathrm), = \\nuup (kpfonts mathdesign), = \\upnu (upgreek), nu, greek"
+  ],
+  [
+    "\\xi",
+    "ξ = \\mathrm{\\xi} (omlmathrm), = \\xiup (kpfonts mathdesign), = \\upxi (upgreek), xi, greek"
+  ],
+  [
+    "\\upomicron",
+    "ο  small omicron, greek"
+  ],
+  [
+    "\\pi",
+    "π = \\mathrm{\\pi} (omlmathrm), = \\piup (kpfonts mathdesign), = \\uppi (upgreek), pi, greek"
+  ],
+  [
+    "\\rho",
+    "ρ = \\mathrm{\\rho} (omlmathrm), = \\rhoup (kpfonts mathdesign), = \\uprho (upgreek), rho, greek"
+  ],
+  [
+    "\\varsigma",
+    "ς = \\mathrm{\\varsigma} (omlmathrm), = \\varsigmaup (kpfonts mathdesign), = \\upvarsigma (upgreek), terminal sigma, greek"
+  ],
+  [
+    "\\sigma",
+    "σ = \\mathrm{\\sigma} (omlmathrm), = \\sigmaup (kpfonts mathdesign), = \\upsigma (upgreek), sigma, greek"
+  ],
+  [
+    "\\tau",
+    "τ = \\mathrm{\\tau} (omlmathrm), = \\tauup (kpfonts mathdesign), = \\uptau (upgreek), tau, greek"
+  ],
+  [
+    "\\upsilon",
+    "υ = \\mathrm{\\upsilon} (omlmathrm), = \\upsilonup (kpfonts mathdesign), = \\upupsilon (upgreek), upsilon, greek"
+  ],
+  [
+    "\\varphi",
+    "φ = \\mathrm{\\varphi} (omlmathrm), = \\varphiup (kpfonts mathdesign), = \\upvarphi (upgreek), curly or open phi, greek"
+  ],
+  [
+    "\\chi",
+    "χ = \\mathrm{\\chi} (omlmathrm), = \\chiup (kpfonts mathdesign), = \\upchi (upgreek), chi, greek"
+  ],
+  [
+    "\\psi",
+    "ψ = \\mathrm{\\psi} (omlmathrm), = \\psiup (kpfonts mathdesign), = \\uppsi (upgreek), psi, greek"
+  ],
+  [
+    "\\omega",
+    "ω = \\mathrm{\\omega} (omlmathrm), = \\omegaup (kpfonts mathdesign), = \\upomega (upgreek), omega, greek"
+  ],
+  [
+    "\\varbeta",
+    "ϐ rounded beta, greek"
+  ],
+  [
+    "\\vartheta",
+    "ϑ = \\mathrm{\\vartheta} (omlmathrm), = \\varthetaup (kpfonts mathdesign), curly or open theta"
+  ],
+  [
+    "\\upUpsilon",
+    "ϒ  # \\mathrm{\\upsilon}, greek upsilon with hook symbol"
+  ],
+  [
+    "\\phi",
+    "ϕ = \\mathrm{\\phi} (omlmathrm), = \\phiup (kpfonts mathdesign), greek phi symbol (straight)"
+  ],
+  [
+    "\\varpi",
+    "ϖ = \\mathrm{\\varpi} (omlmathrm), = \\varpiup (kpfonts mathdesign), greek pi symbol (pomega)"
+  ],
+  [
+    "\\Qoppa",
+    "ϙ = \\koppa (wrisym), t \\qoppa (lgr), greek letter archaic koppa"
+  ],
+  [
+    "\\qoppa",
+    "ϙ = \\koppa (wrisym), t \\qoppa (lgr), greek small letter archaic koppa"
+  ],
+  [
+    "\\Stigma",
+    "ϛ capital stigma"
+  ],
+  [
+    "\\stigma",
+    "ϛ greek small letter stigma"
+  ],
+  [
+    "\\Digamma",
+    "ϝ capital digamma"
+  ],
+  [
+    "\\digamma",
+    "ϝ greek small letter digamma"
+  ],
+  [
+    "\\Koppa",
+    "ϟ capital koppa"
+  ],
+  [
+    "\\koppa",
+    "ϟ greek small letter koppa"
+  ],
+  [
+    "\\Sampi",
+    "ϡ capital sampi"
+  ],
+  [
+    "\\sampi",
+    "ϡ # \\sampi (wrisym), greek small letter sampi"
+  ],
+  [
+    "\\varkappa",
+    "ϰ greek kappa symbol (round)"
+  ],
+  [
+    "\\varrho",
+    "ϱ = \\mathrm{\\varrho} (omlmathrm), = \\varrhoup (kpfonts mathdesign), greek rho symbol (round)"
+  ],
+  [
+    "\\upvarTheta",
+    "θ  x \\vartheta (amssymb), greek capital theta symbol"
+  ],
+  [
+    "\\epsilon",
+    "ϵ = \\mathrm{\\epsilon} (omlmathrm), = \\epsilonup (kpfonts mathdesign), greek lunate epsilon symbol"
+  ],
+  [
+    "\\backepsilon",
+    "϶ greek reversed lunate epsilon symbol"
+  ],
+  [
+    "\\quad",
+    "  emquad"
+  ],
+  [
+    "\\horizbar",
+    "―  horizontal bar"
+  ],
+  [
+    "\\|",
+    "‖ = \\vert, double vertical bar"
+  ],
+  [
+    "\\twolowline",
+    "‗  double low line (spacing)"
+  ],
+  [
+    "\\dagger",
+    "† dagger relation"
+  ],
+  [
+    "\\ddagger",
+    "‡ double dagger relation"
+  ],
+  [
+    "\\bullet",
+    "• bullet (small, filled)"
+  ],
+  [
+    "\\enleadertwodots",
+    "‥  double baseline dot (en leader)"
+  ],
+  [
+    "\\ldots",
+    "… ellipsis (horizontal)"
+  ],
+  [
+    "\\prime",
+    "′ prime or minute, not superscripted"
+  ],
+  [
+    "\\second",
+    "″ double prime or second, not superscripted"
+  ],
+  [
+    "\\third",
+    "‴ triple prime (not superscripted)"
+  ],
+  [
+    "\\backprime",
+    "‵ reverse prime, not superscripted"
+  ],
+  [
+    "\\backdprime",
+    "‶  double reverse prime, not superscripted"
+  ],
+  [
+    "\\backtrprime",
+    "‷  triple reverse prime, not superscripted"
+  ],
+  [
+    "\\caretinsert",
+    "‸  caret (insertion mark)"
+  ],
+  [
+    "\\Exclam",
+    "‼  # !!, double exclamation mark"
+  ],
+  [
+    "\\cat",
+    "⁀ character tie, z notation sequence concatenation"
+  ],
+  [
+    "\\hyphenbullet",
+    "⁃  rectangle, filled (hyphen bullet)"
+  ],
+  [
+    "\\fracslash",
+    "⁄  # /, fraction slash"
+  ],
+  [
+    "\\Question",
+    "⁇  # ??, double question mark"
+  ],
+  [
+    "\\closure",
+    "⁐  close up (editing mark)"
+  ],
+  [
+    "\\fourth",
+    "⁗ quadruple prime, not superscripted"
+  ],
+  [
+    "\\:",
+    "  = \\medspace (amsmath), medium mathematical space, four-eighteenths of an em"
+  ],
+  [
+    "\\euro",
+    "€  euro sign"
+  ],
+  [
+    "\\lvec",
+    "x⃐ combining left harpoon above"
+  ],
+  [
+    "\\vec",
+    "x⃑ combining right harpoon above"
+  ],
+  [
+    "\\vertoverlay",
+    "x⃒  combining long vertical line overlay"
+  ],
+  [
+    "\\LVec",
+    "x⃖ # \\overleftarrow, combining left arrow above"
+  ],
+  [
+    "\\vec",
+    "x⃗ = \\vec (wrisym), # \\overrightarrow, combining right arrow above"
+  ],
+  [
+    "\\dddot",
+    "x⃛ = \\dddot (wrisym), combining three dots above"
+  ],
+  [
+    "\\ddddot",
+    "x⃜ combining four dots above"
+  ],
+  [
+    "\\enclosecircle",
+    "x⃝  combining enclosing circle"
+  ],
+  [
+    "\\enclosesquare",
+    "x⃞  combining enclosing square"
+  ],
+  [
+    "\\enclosediamond",
+    "x⃟  combining enclosing diamond"
+  ],
+  [
+    "\\overleftrightarrow",
+    "x⃡ combining left right arrow above"
+  ],
+  [
+    "\\enclosetriangle",
+    "x⃤  combining enclosing upward pointing triangle"
+  ],
+  [
+    "\\annuity",
+    "x⃧  combining annuity symbol"
+  ],
+  [
+    "\\threeunderdot",
+    "x⃨  combining triple underdot"
+  ],
+  [
+    "\\widebridgeabove",
+    "x⃩  combining wide bridge above"
+  ],
+  [
+    "\\underrightharpoondown",
+    "x⃬  combining rightwards harpoon with barb downwards"
+  ],
+  [
+    "\\underleftharpoondown",
+    "x⃭  combining leftwards harpoon with barb downwards"
+  ],
+  [
+    "\\underleftarrow",
+    "x⃮ combining left arrow below"
+  ],
+  [
+    "\\underrightarrow",
+    "x⃯ combining right arrow below"
+  ],
+  [
+    "\\asteraccent",
+    "x⃰  combining asterisk above"
+  ],
+  [
+    "\\mathbb{C}",
+    "ℂ = \\mathds{c} (dsfont), open face c"
+  ],
+  [
+    "\\Euler",
+    "ℇ euler constant"
+  ],
+  [
+    "\\mathcal{g}",
+    "ℊ /scr g, script small letter g"
+  ],
+  [
+    "\\mathcal{H}",
+    "ℋ hamiltonian (script capital h)"
+  ],
+  [
+    "\\mathfrak{H}",
+    "ℌ /frak h, black-letter capital h"
+  ],
+  [
+    "\\mathbb{H}",
+    "ℍ = \\mathds{h} (dsfont), open face capital h"
+  ],
+  [
+    "\\Planckconst",
+    "ℎ  # h, planck constant"
+  ],
+  [
+    "\\hslash",
+    "ℏ =\\hbar (wrisym), #\\hbar, planck's h over 2pi"
+  ],
+  [
+    "\\mathcal{I}",
+    "ℐ /scr i, script capital i"
+  ],
+  [
+    "\\Im",
+    "ℑ = \\mathfrak{i} (eufrak), imaginary part"
+  ],
+  [
+    "\\mathcal{L}",
+    "ℒ lagrangian (script capital l)"
+  ],
+  [
+    "\\ell",
+    "ℓ cursive small l"
+  ],
+  [
+    "\\mathbb{N}",
+    "ℕ = \\mathds{n} (dsfont), open face n"
+  ],
+  [
+    "\\wp",
+    "℘ weierstrass p"
+  ],
+  [
+    "\\mathbb{P}",
+    "ℙ = \\mathds{p} (dsfont), open face p"
+  ],
+  [
+    "\\mathbb{Q}",
+    "ℚ = \\mathds{q} (dsfont), open face q"
+  ],
+  [
+    "\\mathcal{R}",
+    "ℛ /scr r, script capital r"
+  ],
+  [
+    "\\Re",
+    "ℜ = \\mathfrak{r} (eufrak), real part"
+  ],
+  [
+    "\\mathbb{R}",
+    "ℝ = \\mathds{r} (dsfont), open face r"
+  ],
+  [
+    "\\mathbb{Z}",
+    "ℤ = \\mathds{z} (dsfont), open face z"
+  ],
+  [
+    "\\tcohm",
+    "ω # \\mathrm{\\omega}, ohm (deprecated in math, use greek letter)"
+  ],
+  [
+    "\\mho",
+    "℧ = \\mho (wrisym), t \\agemo (wasysym), conductance"
+  ],
+  [
+    "\\mathfrak{Z}",
+    "ℨ /frak z, black-letter capital z"
+  ],
+  [
+    "\\turnediota",
+    "℩  turned iota"
+  ],
+  [
+    "\\Angstroem",
+    "å # \\mathring{\\mathrm{a}}, ångström capital a with ring"
+  ],
+  [
+    "\\mathcal{B}",
+    "ℬ bernoulli function (script capital b)"
+  ],
+  [
+    "\\mathfrak{C}",
+    "ℭ black-letter capital c"
+  ],
+  [
+    "\\mathcal{e}",
+    "ℯ /scr e, script small letter e"
+  ],
+  [
+    "\\mathcal{E}",
+    "ℰ /scr e, script capital e"
+  ],
+  [
+    "\\mathcal{F}",
+    "ℱ /scr f, script capital f"
+  ],
+  [
+    "\\Finv",
+    "ⅎ turned capital f"
+  ],
+  [
+    "\\mathcal{M}",
+    "ℳ physics m-matrix (script capital m)"
+  ],
+  [
+    "\\mathcal{o}",
+    "ℴ order of (script small o)"
+  ],
+  [
+    "\\aleph",
+    "ℵ aleph, hebrew"
+  ],
+  [
+    "\\beth",
+    "ℶ beth, hebrew"
+  ],
+  [
+    "\\gimel",
+    "ℷ gimel, hebrew"
+  ],
+  [
+    "\\daleth",
+    "ℸ daleth, hebrew"
+  ],
+  [
+    "\\mathbb{\\pi}",
+    "ℼ \\doublepi (wrisym), double-struck small pi"
+  ],
+  [
+    "\\mathbb{\\gamma}",
+    "ℽ \\eulergamma (wrisym), double-struck small gamma"
+  ],
+  [
+    "\\mathbb{\\Gamma}",
+    "ℾ double-struck capital gamma"
+  ],
+  [
+    "\\mathbb{\\Pi}",
+    "ℿ double-struck capital pi"
+  ],
+  [
+    "\\mathbb{\\Sigma}",
+    "⅀ double-struck n-ary summation"
+  ],
+  [
+    "\\Game",
+    "⅁  # \\game (amssymb), turned sans-serif capital g (amssymb has mirrored g)"
+  ],
+  [
+    "\\sansLturned",
+    "⅂  turned sans-serif capital l"
+  ],
+  [
+    "\\sansLmirrored",
+    "⅃  reversed sans-serif capital l"
+  ],
+  [
+    "\\Yup",
+    "⅄ turned sans-serif capital y"
+  ],
+  [
+    "\\CapitalDifferentialD",
+    "ⅅ = \\dd (wrisym), double-struck italic capital d"
+  ],
+  [
+    "\\DifferentialD",
+    "ⅆ = \\dd (wrisym), double-struck italic small d"
+  ],
+  [
+    "\\ExponetialE",
+    "ⅇ = \\ee (wrisym), double-struck italic small e"
+  ],
+  [
+    "\\ComplexI",
+    "ⅈ = \\ii (wrisym), double-struck italic small i"
+  ],
+  [
+    "\\ComplexJ",
+    "ⅉ = \\jj (wrisym), double-struck italic small j"
+  ],
+  [
+    "\\PropertyLine",
+    "⅊  property line"
+  ],
+  [
+    "\\invamp",
+    "⅋ # \\bindnasrepma (stmaryrd), turned ampersand"
+  ],
+  [
+    "\\leftarrow",
+    "← = \\gets, a: leftward arrow"
+  ],
+  [
+    "\\uparrow",
+    "↑ upward arrow"
+  ],
+  [
+    "\\rightarrow",
+    "→ = \\to, = \\tfun (oz), = \\fun (oz), rightward arrow, z notation total function"
+  ],
+  [
+    "\\downarrow",
+    "↓ downward arrow"
+  ],
+  [
+    "\\leftrightarrow",
+    "↔ = \\rel (oz), left right arrow, z notation relation"
+  ],
+  [
+    "\\updownarrow",
+    "↕ up and down arrow"
+  ],
+  [
+    "\\nwarrow",
+    "↖ nw pointing arrow"
+  ],
+  [
+    "\\nearrow",
+    "↗ ne pointing arrow"
+  ],
+  [
+    "\\searrow",
+    "↘ se pointing arrow"
+  ],
+  [
+    "\\swarrow",
+    "↙ sw pointing arrow"
+  ],
+  [
+    "\\nleftarrow",
+    "↚ not left arrow"
+  ],
+  [
+    "\\nrightarrow",
+    "↛ not right arrow"
+  ],
+  [
+    "\\leftwavearrow",
+    "↜  left arrow-wavy"
+  ],
+  [
+    "\\rightwavearrow",
+    "↝  right arrow-wavy"
+  ],
+  [
+    "\\twoheadleftarrow",
+    "↞ left two-headed arrow"
+  ],
+  [
+    "\\twoheaduparrow",
+    "↟  up two-headed arrow"
+  ],
+  [
+    "\\twoheadrightarrow",
+    "↠ = \\tsur (oz), = \\surj (oz), right two-headed arrow, z notation total surjection"
+  ],
+  [
+    "\\twoheaddownarrow",
+    "↡  down two-headed arrow"
+  ],
+  [
+    "\\leftarrowtail",
+    "↢ left arrow-tailed"
+  ],
+  [
+    "\\rightarrowtail",
+    "↣ = \\tinj (oz), = \\inj (oz), right arrow-tailed, z notation total injection"
+  ],
+  [
+    "\\mapsfrom",
+    "↤ = \\mappedfrom (kpfonts), maps to, leftward"
+  ],
+  [
+    "\\MapsUp",
+    "↥ maps to, upward"
+  ],
+  [
+    "\\mapsto",
+    "↦ maps to, rightward, z notation maplet"
+  ],
+  [
+    "\\MapsDown",
+    "↧ maps to, downward"
+  ],
+  [
+    "\\updownarrowbar",
+    "↨  up down arrow with base (perpendicular)"
+  ],
+  [
+    "\\hookleftarrow",
+    "↩ left arrow-hooked"
+  ],
+  [
+    "\\hookrightarrow",
+    "↪ right arrow-hooked"
+  ],
+  [
+    "\\looparrowleft",
+    "↫ left arrow-looped"
+  ],
+  [
+    "\\looparrowright",
+    "↬ right arrow-looped"
+  ],
+  [
+    "\\leftrightsquigarrow",
+    "↭ left and right arr-wavy"
+  ],
+  [
+    "\\nleftrightarrow",
+    "↮ not left and right arrow"
+  ],
+  [
+    "\\lightning",
+    "↯ t \\lightning (marvosym), downwards zigzag arrow"
+  ],
+  [
+    "\\Lsh",
+    "↰ a: upwards arrow with tip leftwards"
+  ],
+  [
+    "\\Rsh",
+    "↱ a: upwards arrow with tip rightwards"
+  ],
+  [
+    "\\dlsh",
+    "↲ left down angled arrow"
+  ],
+  [
+    "\\drsh",
+    "↳ right down angled arrow"
+  ],
+  [
+    "\\linefeed",
+    "↴  rightwards arrow with corner downwards"
+  ],
+  [
+    "\\carriagereturn",
+    "↵  downwards arrow with corner leftward = carriage return"
+  ],
+  [
+    "\\curvearrowleft",
+    "↶ left curved arrow"
+  ],
+  [
+    "\\curvearrowright",
+    "↷ right curved arrow"
+  ],
+  [
+    "\\barovernorthwestarrow",
+    "↸  north west arrow to long bar"
+  ],
+  [
+    "\\barleftarrowrightarrowba",
+    "↹  leftwards arrow to bar over rightwards arrow to bar"
+  ],
+  [
+    "\\circlearrowleft",
+    "↺ = \\leftturn (wasysym), anticlockwise open circle arrow"
+  ],
+  [
+    "\\circlearrowright",
+    "↻ = \\rightturn (wasysym), clockwise open circle arrow"
+  ],
+  [
+    "\\leftharpoonup",
+    "↼ left harpoon-up"
+  ],
+  [
+    "\\leftharpoondown",
+    "↽ left harpoon-down"
+  ],
+  [
+    "\\upharpoonright",
+    "↾ = \\restriction (amssymb), = \\upharpoonrightup (wrisym), a: up harpoon-right"
+  ],
+  [
+    "\\upharpoonleft",
+    "↿ = \\upharpoonleftup (wrisym), up harpoon-left"
+  ],
+  [
+    "\\rightharpoonup",
+    "⇀ right harpoon-up"
+  ],
+  [
+    "\\rightharpoondown",
+    "⇁ right harpoon-down"
+  ],
+  [
+    "\\downharpoonright",
+    "⇂ = \\upharpoonrightdown (wrisym), down harpoon-right"
+  ],
+  [
+    "\\downharpoonleft",
+    "⇃ = \\upharpoonleftdown (wrisym), down harpoon-left"
+  ],
+  [
+    "\\rightleftarrows",
+    "⇄ = \\rightleftarrow (wrisym), right arrow over left arrow"
+  ],
+  [
+    "\\updownarrows",
+    "⇅ = \\uparrowdownarrow (wrisym), up arrow, down arrow"
+  ],
+  [
+    "\\leftrightarrows",
+    "⇆ = \\leftrightarrow (wrisym), left arrow over right arrow"
+  ],
+  [
+    "\\leftleftarrows",
+    "⇇ two left arrows"
+  ],
+  [
+    "\\upuparrows",
+    "⇈ two up arrows"
+  ],
+  [
+    "\\rightrightarrows",
+    "⇉ two right arrows"
+  ],
+  [
+    "\\downdownarrows",
+    "⇊ two down arrows"
+  ],
+  [
+    "\\leftrightharpoons",
+    "⇋ = \\revequilibrium (wrisym), left harpoon over right"
+  ],
+  [
+    "\\rightleftharpoons",
+    "⇌ = \\equilibrium (wrisym), right harpoon over left"
+  ],
+  [
+    "\\nLeftarrow",
+    "⇍ not implied by"
+  ],
+  [
+    "\\nLeftrightarrow",
+    "⇎ not left and right double arrows"
+  ],
+  [
+    "\\nRightarrow",
+    "⇏ not implies"
+  ],
+  [
+    "\\Leftarrow",
+    "⇐ left double arrow"
+  ],
+  [
+    "\\Uparrow",
+    "⇑ up double arrow"
+  ],
+  [
+    "\\Rightarrow",
+    "⇒ right double arrow"
+  ],
+  [
+    "\\Downarrow",
+    "⇓ down double arrow"
+  ],
+  [
+    "\\Leftrightarrow",
+    "⇔ left and right double arrow"
+  ],
+  [
+    "\\Updownarrow",
+    "⇕ up and down double arrow"
+  ],
+  [
+    "\\Nwarrow",
+    "⇖ nw pointing double arrow"
+  ],
+  [
+    "\\Nearrow",
+    "⇗ ne pointing double arrow"
+  ],
+  [
+    "\\Searrow",
+    "⇘ se pointing double arrow"
+  ],
+  [
+    "\\Swarrow",
+    "⇙ sw pointing double arrow"
+  ],
+  [
+    "\\Lleftarrow",
+    "⇚ left triple arrow"
+  ],
+  [
+    "\\Rrightarrow",
+    "⇛ right triple arrow"
+  ],
+  [
+    "\\leftsquigarrow",
+    "⇜ leftwards squiggle arrow"
+  ],
+  [
+    "\\rightsquigarrow",
+    "⇝ rightwards squiggle arrow"
+  ],
+  [
+    "\\nHuparrow",
+    "⇞  upwards arrow with double stroke"
+  ],
+  [
+    "\\nHdownarrow",
+    "⇟  downwards arrow with double stroke"
+  ],
+  [
+    "\\dashleftarrow",
+    "⇠ leftwards dashed arrow"
+  ],
+  [
+    "\\updasharrow",
+    "⇡  upwards dashed arrow"
+  ],
+  [
+    "\\dashrightarrow",
+    "⇢ = \\dasharrow (amsfonts), rightwards dashed arrow"
+  ],
+  [
+    "\\downdasharrow",
+    "⇣  downwards dashed arrow"
+  ],
+  [
+    "\\LeftArrowBar",
+    "⇤ leftwards arrow to bar"
+  ],
+  [
+    "\\RightArrowBar",
+    "⇥ rightwards arrow to bar"
+  ],
+  [
+    "\\leftwhitearrow",
+    "⇦  leftwards white arrow"
+  ],
+  [
+    "\\upwhitearrow",
+    "⇧  upwards white arrow"
+  ],
+  [
+    "\\rightwhitearrow",
+    "⇨  rightwards white arrow"
+  ],
+  [
+    "\\downwhitearrow",
+    "⇩  downwards white arrow"
+  ],
+  [
+    "\\whitearrowupfrombar",
+    "⇪  upwards white arrow from bar"
+  ],
+  [
+    "\\circleonrightarrow",
+    "⇴  right arrow with small circle"
+  ],
+  [
+    "\\downuparrows",
+    "⇵ = \\downarrowuparrow (wrisym), downwards arrow leftwards of upwards arrow"
+  ],
+  [
+    "\\rightthreearrows",
+    "⇶  three rightwards arrows"
+  ],
+  [
+    "\\nvleftarrow",
+    "⇷  leftwards arrow with vertical stroke"
+  ],
+  [
+    "\\pfun",
+    "⇸ rightwards arrow with vertical stroke, z notation partial function"
+  ],
+  [
+    "\\nvleftrightarrow",
+    "⇹  left right arrow with vertical stroke, z notation partial relation"
+  ],
+  [
+    "\\nVleftarrow",
+    "⇺  leftwards arrow with double vertical stroke"
+  ],
+  [
+    "\\ffun",
+    "⇻ rightwards arrow with double vertical stroke, z notation finite function"
+  ],
+  [
+    "\\nVleftrightarrow",
+    "⇼  left right arrow with double vertical stroke, z notation finite relation"
+  ],
+  [
+    "\\leftarrowtriangle",
+    "⇽ leftwards open-headed arrow"
+  ],
+  [
+    "\\rightarrowtriangle",
+    "⇾ rightwards open-headed arrow"
+  ],
+  [
+    "\\leftrightarrowtriangle",
+    "⇿ left right open-headed arrow"
+  ],
+  [
+    "\\forall",
+    "∀ for all"
+  ],
+  [
+    "\\complement",
+    "∁ complement sign"
+  ],
+  [
+    "\\partial",
+    "∂ = \\partialup (kpfonts), partial differential"
+  ],
+  [
+    "\\exists",
+    "∃ = \\exi (oz), at least one exists"
+  ],
+  [
+    "\\nexists",
+    "∄ = \\nexi (oz), negated exists"
+  ],
+  [
+    "\\varnothing",
+    "∅ circle, slash"
+  ],
+  [
+    "\\increment",
+    "∆  # \\mathrm{\\delta}, laplacian (delta; nabla square)"
+  ],
+  [
+    "\\nabla",
+    "∇ nabla, del, hamilton operator"
+  ],
+  [
+    "\\in",
+    "∈ set membership, variant"
+  ],
+  [
+    "\\notin",
+    "∉ = \\nin (wrisym), negated set membership"
+  ],
+  [
+    "\\smallin",
+    "∊  set membership (small set membership)"
+  ],
+  [
+    "\\ni",
+    "∋ = \\owns, contains, variant"
+  ],
+  [
+    "\\nni",
+    "∌ = \\notni (txfonts), = \\notowner (mathabx), = \\notowns (fourier), negated contains, variant"
+  ],
+  [
+    "\\smallni",
+    "∍  r: contains (small contains as member)"
+  ],
+  [
+    "\\QED",
+    "∎  # \\blacksquare (amssymb), end of proof"
+  ],
+  [
+    "\\prod",
+    "∏ product operator"
+  ],
+  [
+    "\\coprod",
+    "∐ coproduct operator"
+  ],
+  [
+    "\\sum",
+    "∑ summation operator"
+  ],
+  [
+    "-",
+    "− minus sign"
+  ],
+  [
+    "\\mp",
+    "∓ minus-or-plus sign"
+  ],
+  [
+    "\\dotplus",
+    "∔ plus sign, dot above"
+  ],
+  [
+    "\\slash",
+    "∕ division slash"
+  ],
+  [
+    "\\smallsetminus",
+    "∖ small set minus (cf. reverse solidus)"
+  ],
+  [
+    "\\ast",
+    "∗ asterisk operator (hodge star operator)"
+  ],
+  [
+    "\\circ",
+    "∘ composite function (small circle)"
+  ],
+  [
+    "\\bullet",
+    "∙ bullet operator"
+  ],
+  [
+    "\\sqrt",
+    "√ radical"
+  ],
+  [
+    "\\sqrt[3]",
+    "∛ cube root"
+  ],
+  [
+    "\\sqrt[4]",
+    "∜ fourth root"
+  ],
+  [
+    "\\propto",
+    "∝ # \\varpropto (amssymb), is proportional to"
+  ],
+  [
+    "\\infty",
+    "∞ infinity"
+  ],
+  [
+    "\\rightangle",
+    "∟ right (90 degree) angle"
+  ],
+  [
+    "\\angle",
+    "∠ angle"
+  ],
+  [
+    "\\measuredangle",
+    "∡ measured angle"
+  ],
+  [
+    "\\sphericalangle",
+    "∢ spherical angle"
+  ],
+  [
+    "\\mid",
+    "∣ r: divides"
+  ],
+  [
+    "\\nmid",
+    "∤ negated mid, does not divide"
+  ],
+  [
+    "\\parallel",
+    "∥ parallel"
+  ],
+  [
+    "\\nparallel",
+    "∦ not parallel"
+  ],
+  [
+    "\\wedge",
+    "∧ = \\land, b: logical and"
+  ],
+  [
+    "\\vee",
+    "∨ = \\lor, b: logical or"
+  ],
+  [
+    "\\cap",
+    "∩ intersection"
+  ],
+  [
+    "\\cup",
+    "∪ union or logical sum"
+  ],
+  [
+    "\\int",
+    "∫ integral operator"
+  ],
+  [
+    "\\iint",
+    "∬ double integral operator"
+  ],
+  [
+    "\\iiint",
+    "∭ triple integral operator"
+  ],
+  [
+    "\\oint",
+    "∮ contour integral operator"
+  ],
+  [
+    "\\oiint",
+    "∯ = \\dbloint (wrisym), double contour integral operator"
+  ],
+  [
+    "\\oiiint",
+    "∰ triple contour integral operator"
+  ],
+  [
+    "\\intclockwise",
+    "∱  clockwise integral"
+  ],
+  [
+    "\\varointclockwise",
+    "∲ = \\clockoint (wrisym), contour integral, clockwise"
+  ],
+  [
+    "\\ointctrclockwise",
+    "∳ = \\cntclockoint (wrisym), contour integral, anticlockwise"
+  ],
+  [
+    "\\therefore",
+    "∴ = \\wasytherefore (wasysym), therefore"
+  ],
+  [
+    "\\because",
+    "∵ because"
+  ],
+  [
+    ":",
+    "∶ x \\colon, ratio"
+  ],
+  [
+    "\\Proportion",
+    "∷ # ::, two colons"
+  ],
+  [
+    "\\dotminus",
+    "∸  minus sign, dot above"
+  ],
+  [
+    "\\eqcolon",
+    "∹ # -: ,excess"
+  ],
+  [
+    "\\dotsminusdots",
+    "∺  minus with four dots, geometric proportion"
+  ],
+  [
+    "\\kernelcontraction",
+    "∻  homothetic"
+  ],
+  [
+    "\\sim",
+    "∼ similar to, tilde operator"
+  ],
+  [
+    "\\backsim",
+    "∽ reverse similar"
+  ],
+  [
+    "\\invlazys",
+    "∾  most positive, inverted lazy s"
+  ],
+  [
+    "\\AC",
+    "∿ sine wave, alternating current"
+  ],
+  [
+    "\\wr",
+    "≀ wreath product"
+  ],
+  [
+    "\\nsim",
+    "≁ not similar"
+  ],
+  [
+    "\\eqsim",
+    "≂ equals, similar"
+  ],
+  [
+    "\\simeq",
+    "≃ similar, equals"
+  ],
+  [
+    "\\nsimeq",
+    "≄ not similar, equals"
+  ],
+  [
+    "\\cong",
+    "≅ congruent with"
+  ],
+  [
+    "\\simneqq",
+    "≆  similar, not equals [vert only for 9573 entity]"
+  ],
+  [
+    "\\ncong",
+    "≇ not congruent with"
+  ],
+  [
+    "\\approx",
+    "≈ approximate"
+  ],
+  [
+    "\\napprox",
+    "≉ not approximate"
+  ],
+  [
+    "\\approxeq",
+    "≊ approximate, equals"
+  ],
+  [
+    "\\approxident",
+    "≋  approximately identical to"
+  ],
+  [
+    "\\backcong",
+    "≌  all equal to"
+  ],
+  [
+    "\\asymp",
+    "≍ asymptotically equal to"
+  ],
+  [
+    "\\Bumpeq",
+    "≎ bumpy equals"
+  ],
+  [
+    "\\bumpeq",
+    "≏ bumpy equals, equals"
+  ],
+  [
+    "\\doteq",
+    "≐ = \\dotequal (wrisym), equals, single dot above"
+  ],
+  [
+    "\\Doteq",
+    "≑ = \\doteqdot (amssymb), /doteq r: equals, even dots"
+  ],
+  [
+    "\\fallingdotseq",
+    "≒ equals, falling dots"
+  ],
+  [
+    "\\risingdotseq",
+    "≓ equals, rising dots"
+  ],
+  [
+    "\\coloneq",
+    "≔ = \\coloneqq (txfonts), = \\setdelayed (wrisym), # := colon, equals"
+  ],
+  [
+    "\\eqcolon",
+    "≕ = \\eqqcolon (txfonts), # =:, equals, colon"
+  ],
+  [
+    "\\eqcirc",
+    "≖ circle on equals sign"
+  ],
+  [
+    "\\circeq",
+    "≗ circle, equals"
+  ],
+  [
+    "\\arceq",
+    "≘  arc, equals; corresponds to"
+  ],
+  [
+    "\\corresponds",
+    "≙ = \\sdef (oz), t \\corresponds (marvosym), corresponds to (wedge over equals)"
+  ],
+  [
+    "\\veeeq",
+    "≚  logical or, equals"
+  ],
+  [
+    "\\stareq",
+    "≛  star equals"
+  ],
+  [
+    "\\triangleq",
+    "≜ = \\varsdef (oz), triangle, equals"
+  ],
+  [
+    "\\eqdef",
+    "≝  equals by definition"
+  ],
+  [
+    "\\measeq",
+    "≞  measured by (m over equals)"
+  ],
+  [
+    "\\questeq",
+    "≟  equal with questionmark"
+  ],
+  [
+    "\\neq",
+    "≠ = \\ne, r: not equal"
+  ],
+  [
+    "\\equiv",
+    "≡ identical with"
+  ],
+  [
+    "\\nequiv",
+    "≢ not identical with"
+  ],
+  [
+    "\\Equiv",
+    "≣  strict equivalence (4 lines)"
+  ],
+  [
+    "\\leq",
+    "≤ = \\le, r: less-than-or-equal"
+  ],
+  [
+    "\\geq",
+    "≥ = \\ge, r: greater-than-or-equal"
+  ],
+  [
+    "\\leqq",
+    "≦ less, double equals"
+  ],
+  [
+    "\\geqq",
+    "≧ greater, double equals"
+  ],
+  [
+    "\\lneqq",
+    "≨ less, not double equals"
+  ],
+  [
+    "\\gneqq",
+    "≩ greater, not double equals"
+  ],
+  [
+    "\\ll",
+    "≪ much less than, type 2"
+  ],
+  [
+    "\\gg",
+    "≫ much greater than, type 2"
+  ],
+  [
+    "\\between",
+    "≬ between"
+  ],
+  [
+    "\\notasymp",
+    "≭ = \\nasymp (wrisym), not asymptotically equal to"
+  ],
+  [
+    "\\nless",
+    "≮ not less-than"
+  ],
+  [
+    "\\ngtr",
+    "≯ not greater-than"
+  ],
+  [
+    "\\nleq",
+    "≰ = \\nleqslant (fourier), not less-than-or-equal"
+  ],
+  [
+    "\\ngeq",
+    "≱ = \\ngeqslant (fourier), not greater-than-or-equal"
+  ],
+  [
+    "\\lesssim",
+    "≲ = \\apprle (wasysym), = \\lesstilde (wrisym), less, similar"
+  ],
+  [
+    "\\gtrsim",
+    "≳ = \\apprge (wasysym), = \\greatertilde (wrisym), greater, similar"
+  ],
+  [
+    "\\NotLessTilde",
+    "≴ not less, similar"
+  ],
+  [
+    "\\NotGreaterTilde",
+    "≵ not greater, similar"
+  ],
+  [
+    "\\lessgtr",
+    "≶ less, greater"
+  ],
+  [
+    "\\gtrless",
+    "≷ = \\greaterless (wrisym), greater, less"
+  ],
+  [
+    "\\nlessgtr",
+    "≸  not less, greater"
+  ],
+  [
+    "\\NotGreaterLess",
+    "≹ not greater, less"
+  ],
+  [
+    "\\prec",
+    "≺ precedes"
+  ],
+  [
+    "\\succ",
+    "≻ succeeds"
+  ],
+  [
+    "\\preccurlyeq",
+    "≼ = \\precedesslantequal (wrisym), precedes, curly equals"
+  ],
+  [
+    "\\succcurlyeq",
+    "≽ = \\succeedsslantequal (wrisym), succeeds, curly equals"
+  ],
+  [
+    "\\precsim",
+    "≾ = \\precedestilde (wrisym), precedes, similar"
+  ],
+  [
+    "\\succsim",
+    "≿ = \\succeedstilde (wrisym), succeeds, similar"
+  ],
+  [
+    "\\nprec",
+    "⊀ not precedes"
+  ],
+  [
+    "\\nsucc",
+    "⊁ not succeeds"
+  ],
+  [
+    "\\subset",
+    "⊂ subset or is implied by"
+  ],
+  [
+    "\\supset",
+    "⊃ superset or implies"
+  ],
+  [
+    "\\nsubset",
+    "⊄ not subset, variant [slash negation]"
+  ],
+  [
+    "\\nsupset",
+    "⊅ not superset, variant [slash negation]"
+  ],
+  [
+    "\\subseteq",
+    "⊆ subset, equals"
+  ],
+  [
+    "\\supseteq",
+    "⊇ superset, equals"
+  ],
+  [
+    "\\nsubseteq",
+    "⊈ not subset, equals"
+  ],
+  [
+    "\\nsupseteq",
+    "⊉ not superset, equals"
+  ],
+  [
+    "\\subsetneq",
+    "⊊ = \\varsubsetneq (fourier), subset, not equals"
+  ],
+  [
+    "\\supsetneq",
+    "⊋ superset, not equals"
+  ],
+  [
+    "\\cupleftarrow",
+    "⊌  multiset"
+  ],
+  [
+    "\\cupdot",
+    "⊍  union, with dot"
+  ],
+  [
+    "\\uplus",
+    "⊎ = \\buni (oz), plus sign in union"
+  ],
+  [
+    "\\sqsubset",
+    "⊏ square subset"
+  ],
+  [
+    "\\sqsupset",
+    "⊐ square superset"
+  ],
+  [
+    "\\sqsubseteq",
+    "⊑ square subset, equals"
+  ],
+  [
+    "\\sqsupseteq",
+    "⊒ square superset, equals"
+  ],
+  [
+    "\\sqcap",
+    "⊓ square intersection"
+  ],
+  [
+    "\\sqcup",
+    "⊔ square union"
+  ],
+  [
+    "\\oplus",
+    "⊕ plus sign in circle"
+  ],
+  [
+    "\\ominus",
+    "⊖ minus sign in circle"
+  ],
+  [
+    "\\otimes",
+    "⊗ multiply sign in circle"
+  ],
+  [
+    "\\oslash",
+    "⊘ solidus in circle"
+  ],
+  [
+    "\\odot",
+    "⊙ middle dot in circle"
+  ],
+  [
+    "\\circledcirc",
+    "⊚ small circle in circle"
+  ],
+  [
+    "\\circledast",
+    "⊛ asterisk in circle"
+  ],
+  [
+    "\\circledequal",
+    "⊜  equal in circle"
+  ],
+  [
+    "\\circleddash",
+    "⊝ hyphen in circle"
+  ],
+  [
+    "\\boxplus",
+    "⊞ plus sign in box"
+  ],
+  [
+    "\\boxminus",
+    "⊟ minus sign in box"
+  ],
+  [
+    "\\boxtimes",
+    "⊠ multiply sign in box"
+  ],
+  [
+    "\\boxdot",
+    "⊡ /dotsquare /boxdot b: small dot in box"
+  ],
+  [
+    "\\vdash",
+    "⊢ right tack, proves, implies, yields, (vertical, dash)"
+  ],
+  [
+    "\\dashv",
+    "⊣ left tack, non-theorem, does not yield, (dash, vertical)"
+  ],
+  [
+    "\\top",
+    "⊤ down tack, top"
+  ],
+  [
+    "\\bot",
+    "⊥ up tack, bottom"
+  ],
+  [
+    "\\vdash",
+    "⊦ assertion (vertical, short dash)"
+  ],
+  [
+    "\\models",
+    "⊧ models (vertical, short double dash)"
+  ],
+  [
+    "\\vDash",
+    "⊨ true (vertical, double dash)"
+  ],
+  [
+    "\\Vdash",
+    "⊩ double vertical, dash"
+  ],
+  [
+    "\\Vvdash",
+    "⊪ triple vertical, dash"
+  ],
+  [
+    "\\VDash",
+    "⊫ double vert, double dash"
+  ],
+  [
+    "\\nvdash",
+    "⊬ not vertical, dash"
+  ],
+  [
+    "\\nvDash",
+    "⊭ not vertical, double dash"
+  ],
+  [
+    "\\nVdash",
+    "⊮ not double vertical, dash"
+  ],
+  [
+    "\\nVDash",
+    "⊯ not double vert, double dash"
+  ],
+  [
+    "\\prurel",
+    "⊰  element precedes under relation"
+  ],
+  [
+    "\\scurel",
+    "⊱  succeeds under relation"
+  ],
+  [
+    "\\vartriangleleft",
+    "⊲ left triangle, open, variant"
+  ],
+  [
+    "\\vartriangleright",
+    "⊳ right triangle, open, variant"
+  ],
+  [
+    "\\trianglelefteq",
+    "⊴ = \\unlhd (wrisym), left triangle, equals"
+  ],
+  [
+    "\\trianglerighteq",
+    "⊵ = \\unrhd (wrisym), right triangle, equals"
+  ],
+  [
+    "\\multimapdotbothA",
+    "⊶ original of"
+  ],
+  [
+    "\\multimapdotbothB",
+    "⊷ image of"
+  ],
+  [
+    "\\multimap",
+    "⊸ /multimap a:"
+  ],
+  [
+    "\\hermitmatrix",
+    "⊹  hermitian conjugate matrix"
+  ],
+  [
+    "\\intercal",
+    "⊺ intercal"
+  ],
+  [
+    "\\veebar",
+    "⊻ logical or, bar below (large vee); exclusive disjunction"
+  ],
+  [
+    "\\barwedge",
+    "⊼ logical nand (bar over wedge)"
+  ],
+  [
+    "\\barvee",
+    "⊽  bar, vee (large vee)"
+  ],
+  [
+    "\\measuredrightangle",
+    "⊾  right angle-measured [with arc]"
+  ],
+  [
+    "\\varlrtriangle",
+    "⊿  right triangle"
+  ],
+  [
+    "\\bigwedge",
+    "⋀ logical or operator"
+  ],
+  [
+    "\\bigvee",
+    "⋁ logical and operator"
+  ],
+  [
+    "\\bigcap",
+    "⋂ = \\dint (oz), \\dinter (oz), intersection operator"
+  ],
+  [
+    "\\bigcup",
+    "⋃ = \\duni (oz), \\dunion (oz), union operator"
+  ],
+  [
+    "\\diamond",
+    "⋄ diamond operator (white diamond)"
+  ],
+  [
+    "\\cdot",
+    "⋅ dot operator (small middle dot)"
+  ],
+  [
+    "\\star",
+    "⋆ small star, filled, low"
+  ],
+  [
+    "\\divideontimes",
+    "⋇ division on times"
+  ],
+  [
+    "\\bowtie",
+    "⋈ = \\lrtimes (txfonts), bowtie"
+  ],
+  [
+    "\\ltimes",
+    "⋉ times sign, left closed"
+  ],
+  [
+    "\\rtimes",
+    "⋊ times sign, right closed"
+  ],
+  [
+    "\\leftthreetimes",
+    "⋋ left semidirect product"
+  ],
+  [
+    "\\rightthreetimes",
+    "⋌ right semidirect product"
+  ],
+  [
+    "\\backsimeq",
+    "⋍ reverse similar, equals"
+  ],
+  [
+    "\\curlyvee",
+    "⋎ curly logical or"
+  ],
+  [
+    "\\curlywedge",
+    "⋏ curly logical and"
+  ],
+  [
+    "\\Subset",
+    "⋐ double subset"
+  ],
+  [
+    "\\Supset",
+    "⋑ double superset"
+  ],
+  [
+    "\\Cap",
+    "⋒ /cap /doublecap b: double intersection"
+  ],
+  [
+    "\\Cup",
+    "⋓ /cup /doublecup b: double union"
+  ],
+  [
+    "\\pitchfork",
+    "⋔ pitchfork"
+  ],
+  [
+    "\\hash",
+    "⋕ parallel, equal; equal or parallel"
+  ],
+  [
+    "\\lessdot",
+    "⋖ less than, with dot"
+  ],
+  [
+    "\\gtrdot",
+    "⋗ greater than, with dot"
+  ],
+  [
+    "\\lll",
+    "⋘ triple less-than"
+  ],
+  [
+    "\\ggg",
+    "⋙ triple greater-than"
+  ],
+  [
+    "\\lesseqgtr",
+    "⋚ less, equals, greater"
+  ],
+  [
+    "\\gtreqless",
+    "⋛ greater, equals, less"
+  ],
+  [
+    "\\eqless",
+    "⋜  equal-or-less"
+  ],
+  [
+    "\\eqgtr",
+    "⋝  equal-or-greater"
+  ],
+  [
+    "\\curlyeqprec",
+    "⋞ curly equals, precedes"
+  ],
+  [
+    "\\curlyeqsucc",
+    "⋟ curly equals, succeeds"
+  ],
+  [
+    "\\npreceq",
+    "⋠ does not precede or equal"
+  ],
+  [
+    "\\nsucceq",
+    "⋡ not succeeds, curly equals"
+  ],
+  [
+    "\\nsqsubseteq",
+    "⋢ not, square subset, equals"
+  ],
+  [
+    "\\nsqsupseteq",
+    "⋣ not, square superset, equals"
+  ],
+  [
+    "\\sqsubsetneq",
+    "⋤  square subset, not equals"
+  ],
+  [
+    "\\sqsupsetneq",
+    "⋥  square superset, not equals"
+  ],
+  [
+    "\\lnsim",
+    "⋦ less, not similar"
+  ],
+  [
+    "\\gnsim",
+    "⋧ greater, not similar"
+  ],
+  [
+    "\\precnsim",
+    "⋨ precedes, not similar"
+  ],
+  [
+    "\\succnsim",
+    "⋩ succeeds, not similar"
+  ],
+  [
+    "\\ntriangleleft",
+    "⋪ = \\notlefttriangle (wrisym), not left triangle"
+  ],
+  [
+    "\\ntriangleright",
+    "⋫ = \\notrighttriangle (wrisym), not right triangle"
+  ],
+  [
+    "\\ntrianglelefteq",
+    "⋬ = \\nunlhd (wrisym), not left triangle, equals"
+  ],
+  [
+    "\\ntrianglerighteq",
+    "⋭ = \\nunrhd (wrisym), not right triangle, equals"
+  ],
+  [
+    "\\vdots",
+    "⋮ vertical ellipsis"
+  ],
+  [
+    "\\cdots",
+    "⋯ three dots, centered"
+  ],
+  [
+    "\\iddots",
+    "⋰ = \\adots (yhmath), three dots, ascending"
+  ],
+  [
+    "\\ddots",
+    "⋱ three dots, descending"
+  ],
+  [
+    "\\disin",
+    "⋲  element of with long horizontal stroke"
+  ],
+  [
+    "\\varisins",
+    "⋳  element of with vertical bar at end of horizontal stroke"
+  ],
+  [
+    "\\isins",
+    "⋴  small element of with vertical bar at end of horizontal stroke"
+  ],
+  [
+    "\\isindot",
+    "⋵  element of with dot above"
+  ],
+  [
+    "\\barin",
+    "⋶ element of with overbar"
+  ],
+  [
+    "\\isinobar",
+    "⋷  small element of with overbar"
+  ],
+  [
+    "\\isinvb",
+    "⋸  element of with underbar"
+  ],
+  [
+    "\\isinE",
+    "⋹  element of with two horizontal strokes"
+  ],
+  [
+    "\\nisd",
+    "⋺  contains with long horizontal stroke"
+  ],
+  [
+    "\\varnis",
+    "⋻  contains with vertical bar at end of horizontal stroke"
+  ],
+  [
+    "\\nis",
+    "⋼  small contains with vertical bar at end of horizontal stroke"
+  ],
+  [
+    "\\varniobar",
+    "⋽  contains with overbar"
+  ],
+  [
+    "\\niobar",
+    "⋾  small contains with overbar"
+  ],
+  [
+    "\\bagmember",
+    "⋿  # \\mathsf{e}, z notation bag membership"
+  ],
+  [
+    "\\diameter",
+    "⌀ # \\varnothing (amssymb), diameter sign"
+  ],
+  [
+    "\\house",
+    "⌂  house"
+  ],
+  [
+    "\\varbarwedge",
+    "⌅  # \\barwedge (amssymb), projective (bar over small wedge) not nand"
+  ],
+  [
+    "\\vardoublebarwedge",
+    "⌆  # \\doublebarwedge (amssymb), perspective (double bar over small wedge)"
+  ],
+  [
+    "\\lceil",
+    "⌈ left ceiling"
+  ],
+  [
+    "\\rceil",
+    "⌉ right ceiling"
+  ],
+  [
+    "\\lfloor",
+    "⌊ left floor"
+  ],
+  [
+    "\\rfloor",
+    "⌋ right floor"
+  ],
+  [
+    "\\invneg",
+    "⌐ reverse not"
+  ],
+  [
+    "\\wasylozenge",
+    "⌑ square lozenge"
+  ],
+  [
+    "\\profline",
+    "⌒  profile of a line"
+  ],
+  [
+    "\\profsurf",
+    "⌓  profile of a surface"
+  ],
+  [
+    "\\viewdata",
+    "⌗  viewdata square"
+  ],
+  [
+    "\\turnednot",
+    "⌙  turned not sign"
+  ],
+  [
+    "\\ulcorner",
+    "⌜ upper left corner"
+  ],
+  [
+    "\\urcorner",
+    "⌝ upper right corner"
+  ],
+  [
+    "\\llcorner",
+    "⌞ lower left corner"
+  ],
+  [
+    "\\lrcorner",
+    "⌟ lower right corner"
+  ],
+  [
+    "\\inttop",
+    "⌠  top half integral"
+  ],
+  [
+    "\\intbottom",
+    "⌡  bottom half integral"
+  ],
+  [
+    "\\frown",
+    "⌢ # \\smallfrown, frown (down curve)"
+  ],
+  [
+    "\\smile",
+    "⌣ # \\smallsmile, smile (up curve)"
+  ],
+  [
+    "\\varhexagonlrbonds",
+    "⌬  six carbon ring, corner down, double bonds lower right etc"
+  ],
+  [
+    "\\conictaper",
+    "⌲  conical taper"
+  ],
+  [
+    "\\topbot",
+    "⌶  apl functional symbol i-beam, top and bottom"
+  ],
+  [
+    "\\APLinv",
+    "⌹ apl functional symbol quad divide"
+  ],
+  [
+    "\\obar",
+    "⌽  # \\aplvert{\\circle} (wasysym), x \\obar (stmaryrd), apl functional symbol circle stile, circle with vertical bar"
+  ],
+  [
+    "\\notslash",
+    "⌿ apl functional symbol slash bar, solidus, bar through"
+  ],
+  [
+    "\\notbackslash",
+    "⍀ apl functional symbol backslash bar"
+  ],
+  [
+    "\\APLleftarrowbox",
+    "⍇ apl functional symbol quad leftwards arrow"
+  ],
+  [
+    "\\APLrightarrowbox",
+    "⍈ apl functional symbol quad rightwards arrow"
+  ],
+  [
+    "\\invdiameter",
+    "⍉ apl functional symbol circle backslash"
+  ],
+  [
+    "\\APLuparrowbox",
+    "⍐ apl functional symbol quad upwards arrow"
+  ],
+  [
+    "\\APLboxupcaret",
+    "⍓  apl functional symbol quad up caret"
+  ],
+  [
+    "\\APLdownarrowbox",
+    "⍗ apl functional symbol quad downwards arrow"
+  ],
+  [
+    "\\APLcomment",
+    "⍝ apl functional symbol up shoe jot"
+  ],
+  [
+    "\\APLinput",
+    "⍞ apl functional symbol quote quad"
+  ],
+  [
+    "\\APLlog",
+    "⍟ apl functional symbol circle star"
+  ],
+  [
+    "\\APLboxquestion",
+    "⍰  apl functional symbol quad question"
+  ],
+  [
+    "\\rangledownzigzagarrow",
+    "⍼  right angle with downwards zigzag arrow"
+  ],
+  [
+    "\\hexagon",
+    "⎔  horizontal benzene ring [hexagon flat open]"
+  ],
+  [
+    "\\lparenuend",
+    "⎛  left parenthesis upper hook"
+  ],
+  [
+    "\\lparenextender",
+    "⎜  left parenthesis extension"
+  ],
+  [
+    "\\lparenlend",
+    "⎝  left parenthesis lower hook"
+  ],
+  [
+    "\\rparenuend",
+    "⎞  right parenthesis upper hook"
+  ],
+  [
+    "\\rparenextender",
+    "⎟  right parenthesis extension"
+  ],
+  [
+    "\\rparenlend",
+    "⎠  right parenthesis lower hook"
+  ],
+  [
+    "\\lbrackuend",
+    "⎡  left square bracket upper corner"
+  ],
+  [
+    "\\lbrackextender",
+    "⎢  left square bracket extension"
+  ],
+  [
+    "\\lbracklend",
+    "⎣  left square bracket lower corner"
+  ],
+  [
+    "\\rbrackuend",
+    "⎤  right square bracket upper corner"
+  ],
+  [
+    "\\rbrackextender",
+    "⎥  right square bracket extension"
+  ],
+  [
+    "\\rbracklend",
+    "⎦  right square bracket lower corner"
+  ],
+  [
+    "\\lbraceuend",
+    "⎧  left curly bracket upper hook"
+  ],
+  [
+    "\\lbracemid",
+    "⎨  left curly bracket middle piece"
+  ],
+  [
+    "\\lbracelend",
+    "⎩  left curly bracket lower hook"
+  ],
+  [
+    "\\vbraceextender",
+    "⎪  curly bracket extension"
+  ],
+  [
+    "\\rbraceuend",
+    "⎫  right curly bracket upper hook"
+  ],
+  [
+    "\\rbracemid",
+    "⎬  right curly bracket middle piece"
+  ],
+  [
+    "\\rbracelend",
+    "⎭  right curly bracket lower hook"
+  ],
+  [
+    "\\intextender",
+    "⎮  integral extension"
+  ],
+  [
+    "\\harrowextender",
+    "⎯  horizontal line extension (used to extend arrows)"
+  ],
+  [
+    "\\lmoustache",
+    "⎰  ? \\lmoustache, upper left or lower right curly bracket section"
+  ],
+  [
+    "\\rmoustache",
+    "⎱  ? \\rmoustache, upper right or lower left curly bracket section"
+  ],
+  [
+    "\\sumtop",
+    "⎲  summation top"
+  ],
+  [
+    "\\sumbottom",
+    "⎳  summation bottom"
+  ],
+  [
+    "\\overbracket",
+    "⎴  top square bracket"
+  ],
+  [
+    "\\underbracket",
+    "⎵  bottom square bracket"
+  ],
+  [
+    "\\bbrktbrk",
+    "⎶  bottom square bracket over top square bracket"
+  ],
+  [
+    "\\sqrtbottom",
+    "⎷  radical symbol bottom"
+  ],
+  [
+    "\\lvboxline",
+    "⎸  left vertical box line"
+  ],
+  [
+    "\\rvboxline",
+    "⎹  right vertical box line"
+  ],
+  [
+    "\\varcarriagereturn",
+    "⏎  return symbol"
+  ],
+  [
+    "\\overparen",
+    "⏜ = \\wideparen (yhmath mathabx fourier), top parenthesis (mathematical use)"
+  ],
+  [
+    "\\underparen",
+    "⏝ bottom parenthesis (mathematical use)"
+  ],
+  [
+    "\\overbrace",
+    "⏞ top curly bracket (mathematical use)"
+  ],
+  [
+    "\\underbrace",
+    "⏟ bottom curly bracket (mathematical use)"
+  ],
+  [
+    "\\obrbrak",
+    "⏠  top tortoise shell bracket (mathematical use)"
+  ],
+  [
+    "\\ubrbrak",
+    "⏡  bottom tortoise shell bracket (mathematical use)"
+  ],
+  [
+    "\\trapezium",
+    "⏢  white trapezium"
+  ],
+  [
+    "\\benzenr",
+    "⏣  benzene ring with circle"
+  ],
+  [
+    "\\strns",
+    "⏤  straightness"
+  ],
+  [
+    "\\fltns",
+    "⏥  flatness"
+  ],
+  [
+    "\\accurrent",
+    "⏦  # \\ac (wasysym), ac current"
+  ],
+  [
+    "\\elinters",
+    "⏧  electrical intersection"
+  ],
+  [
+    "\\bdtriplevdash",
+    "┆  doubly broken vert"
+  ],
+  [
+    "\\blockuphalf",
+    "▀  upper half block"
+  ],
+  [
+    "\\blocklowhalf",
+    "▄  lower half block"
+  ],
+  [
+    "\\blockfull",
+    "█  full block"
+  ],
+  [
+    "\\blocklefthalf",
+    "▌  left half block"
+  ],
+  [
+    "\\blockrighthalf",
+    "▐  right half block"
+  ],
+  [
+    "\\blockqtrshaded",
+    "░  25\\% shaded block"
+  ],
+  [
+    "\\blockhalfshaded",
+    "▒  50\\% shaded block"
+  ],
+  [
+    "\\blockthreeqtrshaded",
+    "▓  75\\% shaded block"
+  ],
+  [
+    "\\mdlgblksquare",
+    "■  square, filled"
+  ],
+  [
+    "\\mdlgwhtsquare",
+    "□  square, open"
+  ],
+  [
+    "\\squoval",
+    "▢  white square with rounded corners"
+  ],
+  [
+    "\\blackinwhitesquare",
+    "▣  white square containing black small square"
+  ],
+  [
+    "\\squarehfill",
+    "▤  square, horizontal rule filled"
+  ],
+  [
+    "\\squarevfill",
+    "▥  square, vertical rule filled"
+  ],
+  [
+    "\\squarehvfill",
+    "▦  square with orthogonal crosshatch fill"
+  ],
+  [
+    "\\squarenwsefill",
+    "▧  square, nw-to-se rule filled"
+  ],
+  [
+    "\\squareneswfill",
+    "▨  square, ne-to-sw rule filled"
+  ],
+  [
+    "\\squarecrossfill",
+    "▩  square with diagonal crosshatch fill"
+  ],
+  [
+    "\\smblksquare",
+    "▪  sq bullet, filled"
+  ],
+  [
+    "\\smwhtsquare",
+    "▫  white small square"
+  ],
+  [
+    "\\hrectangleblack",
+    "▬  black rectangle"
+  ],
+  [
+    "\\hrectangle",
+    "▭  horizontal rectangle, open"
+  ],
+  [
+    "\\vrectangleblack",
+    "▮  black vertical rectangle"
+  ],
+  [
+    "\\vrectangle",
+    "▯  rectangle, white (vertical)"
+  ],
+  [
+    "\\parallelogramblack",
+    "▰  black parallelogram"
+  ],
+  [
+    "\\parallelogram",
+    "▱  parallelogram, open"
+  ],
+  [
+    "\\bigblacktriangleup",
+    "▲  black up-pointing triangle"
+  ],
+  [
+    "\\bigtriangleup",
+    "△ = \\triangle (amsfonts), # \\vartriangle (amssymb), big up triangle, open"
+  ],
+  [
+    "\\blacktriangleup",
+    "▴ up triangle, filled"
+  ],
+  [
+    "\\smalltriangleup",
+    "▵ # \\vartriangle (amssymb), small up triangle, open"
+  ],
+  [
+    "\\RHD",
+    "▶ = \\blacktriangleright (fourier -mathabx), (large) right triangle, filled"
+  ],
+  [
+    "\\rhd",
+    "▷ = \\rres (oz), = \\righttriangle (wrisym), (large) right triangle, open; z notation range restriction"
+  ],
+  [
+    "\\blacktriangleright",
+    "▸ right triangle, filled"
+  ],
+  [
+    "\\smalltriangleright",
+    "▹ # \\triangleright, x \\triangleright (mathabx), right triangle, open"
+  ],
+  [
+    "\\blackpointerright",
+    "►  black right-pointing pointer"
+  ],
+  [
+    "\\whitepointerright",
+    "▻  # \\triangleright (mathabx), white right-pointing pointer"
+  ],
+  [
+    "\\bigblacktriangledown",
+    "▼  big down triangle, filled"
+  ],
+  [
+    "\\bigtriangledown",
+    "▽ big down triangle, open"
+  ],
+  [
+    "\\blacktriangledown",
+    "▾ black down-pointing small triangle"
+  ],
+  [
+    "\\smalltriangledown",
+    "▿ # \\triangledown (amssymb), white down-pointing small triangle"
+  ],
+  [
+    "\\LHD",
+    "◀ = \\blacktriangleleft (fourier -mathabx), (large) left triangle, filled"
+  ],
+  [
+    "\\lhd",
+    "◁ = \\dres (oz), = \\lefttriangle (wrisym), (large) left triangle, open; z notation domain restriction"
+  ],
+  [
+    "\\blacktriangleleft",
+    "◂ left triangle, filled"
+  ],
+  [
+    "\\smalltriangleleft",
+    "◃ # \\triangleleft, x \\triangleleft (mathabx), left triangle, open"
+  ],
+  [
+    "\\blackpointerleft",
+    "◄  black left-pointing pointer"
+  ],
+  [
+    "\\whitepointerleft",
+    "◅  # \\triangleleft (mathabx), white left-pointing pointer"
+  ],
+  [
+    "\\Diamondblack",
+    "◆ black diamond"
+  ],
+  [
+    "\\Diamond",
+    "◇ white diamond; diamond, open"
+  ],
+  [
+    "\\blackinwhitediamond",
+    "◈  white diamond containing black small diamond"
+  ],
+  [
+    "\\fisheye",
+    "◉  fisheye"
+  ],
+  [
+    "\\lozenge",
+    "◊ lozenge or total mark"
+  ],
+  [
+    "\\Circle",
+    "○ medium large circle"
+  ],
+  [
+    "\\dottedcircle",
+    "◌  dotted circle"
+  ],
+  [
+    "\\circlevertfill",
+    "◍  circle with vertical fill"
+  ],
+  [
+    "\\bullseye",
+    "◎  # \\circledcirc (amssymb), bullseye"
+  ],
+  [
+    "\\CIRCLE",
+    "● circle, filled"
+  ],
+  [
+    "\\LEFTcircle",
+    "◐ circle, filled left half [harvey ball]"
+  ],
+  [
+    "\\RIGHTcircle",
+    "◑ circle, filled right half"
+  ],
+  [
+    "\\circlebottomhalfblack",
+    "◒  circle, filled bottom half"
+  ],
+  [
+    "\\circletophalfblack",
+    "◓  circle, filled top half"
+  ],
+  [
+    "\\circleurquadblack",
+    "◔  circle with upper right quadrant black"
+  ],
+  [
+    "\\blackcircleulquadwhite",
+    "◕  circle with all but upper left quadrant black"
+  ],
+  [
+    "\\LEFTCIRCLE",
+    "◖ left half black circle"
+  ],
+  [
+    "\\RIGHTCIRCLE",
+    "◗ right half black circle"
+  ],
+  [
+    "\\inversebullet",
+    "◘  inverse bullet"
+  ],
+  [
+    "\\inversewhitecircle",
+    "◙  inverse white circle"
+  ],
+  [
+    "\\invwhiteupperhalfcircle",
+    "◚  upper half inverse white circle"
+  ],
+  [
+    "\\invwhitelowerhalfcircle",
+    "◛  lower half inverse white circle"
+  ],
+  [
+    "\\ularc",
+    "◜  upper left quadrant circular arc"
+  ],
+  [
+    "\\urarc",
+    "◝  upper right quadrant circular arc"
+  ],
+  [
+    "\\lrarc",
+    "◞  lower right quadrant circular arc"
+  ],
+  [
+    "\\llarc",
+    "◟  lower left quadrant circular arc"
+  ],
+  [
+    "\\topsemicircle",
+    "◠  upper half circle"
+  ],
+  [
+    "\\botsemicircle",
+    "◡  lower half circle"
+  ],
+  [
+    "\\lrblacktriangle",
+    "◢  lower right triangle, filled"
+  ],
+  [
+    "\\llblacktriangle",
+    "◣  lower left triangle, filled"
+  ],
+  [
+    "\\ulblacktriangle",
+    "◤  upper left triangle, filled"
+  ],
+  [
+    "\\urblacktriangle",
+    "◥  upper right triangle, filled"
+  ],
+  [
+    "\\smwhtcircle",
+    "◦  white bullet"
+  ],
+  [
+    "\\squareleftblack",
+    "◧  square, filled left half"
+  ],
+  [
+    "\\squarerightblack",
+    "◨  square, filled right half"
+  ],
+  [
+    "\\squareulblack",
+    "◩  square, filled top left corner"
+  ],
+  [
+    "\\squarelrblack",
+    "◪  square, filled bottom right corner"
+  ],
+  [
+    "\\boxbar",
+    "◫ vertical bar in box"
+  ],
+  [
+    "\\trianglecdot",
+    "◬  triangle with centered dot"
+  ],
+  [
+    "\\triangleleftblack",
+    "◭  up-pointing triangle with left half black"
+  ],
+  [
+    "\\trianglerightblack",
+    "◮  up-pointing triangle with right half black"
+  ],
+  [
+    "\\lgwhtcircle",
+    "◯  large circle"
+  ],
+  [
+    "\\squareulquad",
+    "◰  white square with upper left quadrant"
+  ],
+  [
+    "\\squarellquad",
+    "◱  white square with lower left quadrant"
+  ],
+  [
+    "\\squarelrquad",
+    "◲  white square with lower right quadrant"
+  ],
+  [
+    "\\squareurquad",
+    "◳  white square with upper right quadrant"
+  ],
+  [
+    "\\circleulquad",
+    "◴  white circle with upper left quadrant"
+  ],
+  [
+    "\\circlellquad",
+    "◵  white circle with lower left quadrant"
+  ],
+  [
+    "\\circlelrquad",
+    "◶  white circle with lower right quadrant"
+  ],
+  [
+    "\\circleurquad",
+    "◷  white circle with upper right quadrant"
+  ],
+  [
+    "\\ultriangle",
+    "◸  upper left triangle"
+  ],
+  [
+    "\\urtriangle",
+    "◹  upper right triangle"
+  ],
+  [
+    "\\lltriangle",
+    "◺  lower left triangle"
+  ],
+  [
+    "\\square",
+    "◻ white medium square"
+  ],
+  [
+    "\\blacksquare",
+    "◼ black medium square"
+  ],
+  [
+    "\\mdsmwhtsquare",
+    "◽  white medium small square"
+  ],
+  [
+    "\\mdsmblksquare",
+    "◾  black medium small square"
+  ],
+  [
+    "\\lrtriangle",
+    "◿  lower right triangle"
+  ],
+  [
+    "\\bigstar",
+    "★ star, filled"
+  ],
+  [
+    "\\bigwhitestar",
+    "☆  star, open"
+  ],
+  [
+    "\\Sun",
+    "☉ sun"
+  ],
+  [
+    "\\Square",
+    "☐ ballot box"
+  ],
+  [
+    "\\CheckedBox",
+    "☑ t \\checkedbox (marvosym), ballot box with check"
+  ],
+  [
+    "\\XBox",
+    "☒ t \\crossedbox (marvosym), ballot box with x"
+  ],
+  [
+    "\\steaming",
+    "☕ hot beverage"
+  ],
+  [
+    "\\pointright",
+    "☞ white right pointing index"
+  ],
+  [
+    "\\skull",
+    "☠ skull and crossbones"
+  ],
+  [
+    "\\danger",
+    "☡  caution sign, dangerous bend"
+  ],
+  [
+    "\\radiation",
+    "☢ radioactive sign"
+  ],
+  [
+    "\\biohazard",
+    "☣ biohazard sign"
+  ],
+  [
+    "\\yinyang",
+    "☯ yin yang"
+  ],
+  [
+    "\\frownie",
+    "☹ = \\sadface (arevmath), white frowning face"
+  ],
+  [
+    "\\smiley",
+    "☺ = \\smileface (arevmath), white smiling face"
+  ],
+  [
+    "\\blacksmiley",
+    "☻ = \\invsmileface (arevmath), black smiling face"
+  ],
+  [
+    "\\sun",
+    "☼ white sun with rays"
+  ],
+  [
+    "\\rightmoon",
+    "☽ first quarter moon"
+  ],
+  [
+    "\\leftmoon",
+    "☾ last quarter moon"
+  ],
+  [
+    "\\mercury",
+    "☿ = \\mercury (mathabx), mercury"
+  ],
+  [
+    "\\female",
+    "♀ = \\venus (mathabx), = \\girl (mathabx), venus, female"
+  ],
+  [
+    "\\earth",
+    "♁ = \\varearth (mathabx), earth"
+  ],
+  [
+    "\\male",
+    "♂ = \\mars (mathabx), = \\boy (mathabx), mars, male"
+  ],
+  [
+    "\\jupiter",
+    "♃ = \\jupiter (mathabx), jupiter"
+  ],
+  [
+    "\\saturn",
+    "♄ = \\saturn (mathabx), saturn"
+  ],
+  [
+    "\\uranus",
+    "♅ = \\uranus (mathabx), uranus"
+  ],
+  [
+    "\\neptune",
+    "♆ = \\neptune (mathabx), neptune"
+  ],
+  [
+    "\\pluto",
+    "♇ = \\pluto (mathabx), pluto"
+  ],
+  [
+    "\\aries",
+    "♈ = \\aries (mathabx), aries"
+  ],
+  [
+    "\\taurus",
+    "♉ = \\taurus (mathabx), taurus"
+  ],
+  [
+    "\\gemini",
+    "♊ = \\gemini (mathabx), gemini"
+  ],
+  [
+    "\\cancer",
+    "♋ cancer"
+  ],
+  [
+    "\\leo",
+    "♌ = \\leo (mathabx), leo"
+  ],
+  [
+    "\\virgo",
+    "♍ virgo"
+  ],
+  [
+    "\\libra",
+    "♎ = \\libra (mathabx), libra"
+  ],
+  [
+    "\\scorpio",
+    "♏ = \\scorpio (mathabx), scorpius"
+  ],
+  [
+    "\\sagittarius",
+    "♐ sagittarius"
+  ],
+  [
+    "\\capricornus",
+    "♑ capricorn"
+  ],
+  [
+    "\\aquarius",
+    "♒ aquarius"
+  ],
+  [
+    "\\pisces",
+    "♓ pisces"
+  ],
+  [
+    "\\spadesuit",
+    "♠ spades suit symbol"
+  ],
+  [
+    "\\heartsuit",
+    "♡ heart suit symbol"
+  ],
+  [
+    "\\diamondsuit",
+    "♢ diamond suit symbol"
+  ],
+  [
+    "\\clubsuit",
+    "♣ club suit symbol"
+  ],
+  [
+    "\\varspadesuit",
+    "♤ = \\varspade (arevmath), spade, white (card suit)"
+  ],
+  [
+    "\\varheartsuit",
+    "♥ = \\varheart (arevmath), filled heart (card suit)"
+  ],
+  [
+    "\\vardiamondsuit",
+    "♦ = \\vardiamond (arevmath), filled diamond (card suit)"
+  ],
+  [
+    "\\varclubsuit",
+    "♧ = \\varclub (arevmath), club, white (card suit)"
+  ],
+  [
+    "\\quarternote",
+    "♩ music note (sung text sign)"
+  ],
+  [
+    "\\eighthnote",
+    "♪ eighth note"
+  ],
+  [
+    "\\twonotes",
+    "♫ beamed eighth notes"
+  ],
+  [
+    "\\sixteenthnote",
+    "♬ beamed sixteenth notes"
+  ],
+  [
+    "\\flat",
+    "♭ musical flat"
+  ],
+  [
+    "\\natural",
+    "♮ music natural"
+  ],
+  [
+    "\\sharp",
+    "♯ = \\# (oz), music sharp sign, z notation infix bag count"
+  ],
+  [
+    "\\recycle",
+    "♻ black universal recycling symbol"
+  ],
+  [
+    "\\acidfree",
+    "♾  permanent paper sign"
+  ],
+  [
+    "\\dicei",
+    "⚀  die face-1"
+  ],
+  [
+    "\\diceii",
+    "⚁  die face-2"
+  ],
+  [
+    "\\diceiii",
+    "⚂  die face-3"
+  ],
+  [
+    "\\diceiv",
+    "⚃  die face-4"
+  ],
+  [
+    "\\dicev",
+    "⚄  die face-5"
+  ],
+  [
+    "\\dicevi",
+    "⚅  die face-6"
+  ],
+  [
+    "\\circledrightdot",
+    "⚆  white circle with dot right"
+  ],
+  [
+    "\\circledtwodots",
+    "⚇  white circle with two dots"
+  ],
+  [
+    "\\blackcircledrightdot",
+    "⚈  black circle with white dot right"
+  ],
+  [
+    "\\blackcircledtwodots",
+    "⚉  black circle with two white dots"
+  ],
+  [
+    "\\anchor",
+    "⚓ anchor"
+  ],
+  [
+    "\\swords",
+    "⚔ crossed swords"
+  ],
+  [
+    "\\warning",
+    "⚠ warning sign"
+  ],
+  [
+    "\\Hermaphrodite",
+    "⚥  male and female sign"
+  ],
+  [
+    "\\medcirc",
+    "⚪ medium white circle"
+  ],
+  [
+    "\\medbullet",
+    "⚫ medium black circle"
+  ],
+  [
+    "\\mdsmwhtcircle",
+    "⚬  medium small white circle"
+  ],
+  [
+    "\\neuter",
+    "⚲  neuter"
+  ],
+  [
+    "\\pencil",
+    "✎ lower right pencil"
+  ],
+  [
+    "\\checkmark",
+    "✓ = \\ballotcheck (arevmath), tick, check mark"
+  ],
+  [
+    "\\ballotx",
+    "✗ ballot x"
+  ],
+  [
+    "\\maltese",
+    "✠ maltese cross"
+  ],
+  [
+    "\\circledstar",
+    "✪  circled white star"
+  ],
+  [
+    "\\varstar",
+    "✶  six pointed black star"
+  ],
+  [
+    "\\dingasterisk",
+    "✽  heavy teardrop-spoked asterisk"
+  ],
+  [
+    "\\lbrbrak",
+    "❲  light left tortoise shell bracket ornament"
+  ],
+  [
+    "\\rbrbrak",
+    "❳  light right tortoise shell bracket ornament"
+  ],
+  [
+    "\\draftingarrow",
+    "➛  right arrow with bold head (drafting)"
+  ],
+  [
+    "\\arrowbullet",
+    "➢ three-d top-lighted rightwards arrowhead"
+  ],
+  [
+    "\\threedangle",
+    "⟀  three dimensional angle"
+  ],
+  [
+    "\\whiteinwhitetriangle",
+    "⟁  white triangle containing small white triangle"
+  ],
+  [
+    "\\perp",
+    "⟂ perpendicular"
+  ],
+  [
+    "\\subsetcirc",
+    "⟃  open subset"
+  ],
+  [
+    "\\supsetcirc",
+    "⟄  open superset"
+  ],
+  [
+    "\\Lbag",
+    "⟅ = \\lbag (stmaryrd -oz), left s-shaped bag delimiter"
+  ],
+  [
+    "\\Rbag",
+    "⟆ = \\rbag (stmaryrd -oz), right s-shaped bag delimiter"
+  ],
+  [
+    "\\veedot",
+    "⟇  or with dot inside"
+  ],
+  [
+    "\\bsolhsub",
+    "⟈  reverse solidus preceding subset"
+  ],
+  [
+    "\\suphsol",
+    "⟉  superset preceding solidus"
+  ],
+  [
+    "\\longdivision",
+    "⟌  long division"
+  ],
+  [
+    "\\Diamonddot",
+    "⟐ white diamond with centred dot"
+  ],
+  [
+    "\\wedgedot",
+    "⟑  and with dot"
+  ],
+  [
+    "\\upin",
+    "⟒  element of opening upwards"
+  ],
+  [
+    "\\pullback",
+    "⟓  lower right corner with dot"
+  ],
+  [
+    "\\pushout",
+    "⟔  upper left corner with dot"
+  ],
+  [
+    "\\leftouterjoin",
+    "⟕  left outer join"
+  ],
+  [
+    "\\rightouterjoin",
+    "⟖  right outer join"
+  ],
+  [
+    "\\fullouterjoin",
+    "⟗  full outer join"
+  ],
+  [
+    "\\bigbot",
+    "⟘  large up tack"
+  ],
+  [
+    "\\bigtop",
+    "⟙  large down tack"
+  ],
+  [
+    "\\DashVDash",
+    "⟚  left and right double turnstile"
+  ],
+  [
+    "\\dashVdash",
+    "⟛  left and right tack"
+  ],
+  [
+    "\\multimapinv",
+    "⟜ left multimap"
+  ],
+  [
+    "\\vlongdash",
+    "⟝  long left tack"
+  ],
+  [
+    "\\longdashv",
+    "⟞  long right tack"
+  ],
+  [
+    "\\cirbot",
+    "⟟  up tack with circle above"
+  ],
+  [
+    "\\lozengeminus",
+    "⟠  lozenge divided by horizontal rule"
+  ],
+  [
+    "\\concavediamond",
+    "⟡  white concave-sided diamond"
+  ],
+  [
+    "\\concavediamondtickleft",
+    "⟢  white concave-sided diamond with leftwards tick"
+  ],
+  [
+    "\\concavediamondtickright",
+    "⟣  white concave-sided diamond with rightwards tick"
+  ],
+  [
+    "\\whitesquaretickleft",
+    "⟤  white square with leftwards tick"
+  ],
+  [
+    "\\whitesquaretickright",
+    "⟥  white square with rightwards tick"
+  ],
+  [
+    "\\llbracket",
+    "⟦ = \\lbrack (mathbbol), = \\lbag (oz -stmaryrd), mathematical left white square bracket"
+  ],
+  [
+    "\\rrbracket",
+    "⟧ = \\rbrack (mathbbol), = \\rbag (oz -stmaryrd), mathematical right white square bracket"
+  ],
+  [
+    "\\langle",
+    "⟨ mathematical left angle bracket"
+  ],
+  [
+    "\\rangle",
+    "⟩ mathematical right angle bracket"
+  ],
+  [
+    "\\lang",
+    "⟪ mathematical left double angle bracket, z notation left chevron bracket"
+  ],
+  [
+    "\\rang",
+    "⟫ mathematical right double angle bracket, z notation right chevron bracket"
+  ],
+  [
+    "\\Lbrbrak",
+    "⟬  mathematical left white tortoise shell bracket"
+  ],
+  [
+    "\\Rbrbrak",
+    "⟭  mathematical right white tortoise shell bracket"
+  ],
+  [
+    "\\lgroup",
+    "⟮ mathematical left flattened parenthesis"
+  ],
+  [
+    "\\rgroup",
+    "⟯ mathematical right flattened parenthesis"
+  ],
+  [
+    "\\UUparrow",
+    "⟰  upwards quadruple arrow"
+  ],
+  [
+    "\\DDownarrow",
+    "⟱  downwards quadruple arrow"
+  ],
+  [
+    "\\acwgapcirclearrow",
+    "⟲  anticlockwise gapped circle arrow"
+  ],
+  [
+    "\\cwgapcirclearrow",
+    "⟳  clockwise gapped circle arrow"
+  ],
+  [
+    "\\rightarrowonoplus",
+    "⟴  right arrow with circled plus"
+  ],
+  [
+    "\\longleftarrow",
+    "⟵ long leftwards arrow"
+  ],
+  [
+    "\\longrightarrow",
+    "⟶ long rightwards arrow"
+  ],
+  [
+    "\\longleftrightarrow",
+    "⟷ long left right arrow"
+  ],
+  [
+    "\\Longleftarrow",
+    "⟸ = \\impliedby (amsmath), long leftwards double arrow"
+  ],
+  [
+    "\\Longrightarrow",
+    "⟹ = \\implies (amsmath), long rightwards double arrow"
+  ],
+  [
+    "\\Longleftrightarrow",
+    "⟺ = \\iff (oz), long left right double arrow"
+  ],
+  [
+    "\\longmapsfrom",
+    "⟻ = \\longmappedfrom (kpfonts), long leftwards arrow from bar"
+  ],
+  [
+    "\\longmapsto",
+    "⟼ long rightwards arrow from bar"
+  ],
+  [
+    "\\Longmapsfrom",
+    "⟽ = \\longmappedfrom (kpfonts), long leftwards double arrow from bar"
+  ],
+  [
+    "\\Longmapsto",
+    "⟾ long rightwards double arrow from bar"
+  ],
+  [
+    "\\longrightsquigarrow",
+    "⟿  long rightwards squiggle arrow"
+  ],
+  [
+    "\\psur",
+    "⤀ = \\psurj (oz), rightwards two-headed arrow with vertical stroke, z notation partial surjection"
+  ],
+  [
+    "\\nVtwoheadrightarrow",
+    "⤁  rightwards two-headed arrow with double vertical stroke, z notation finite surjection"
+  ],
+  [
+    "\\nvLeftarrow",
+    "⤂  leftwards double arrow with vertical stroke"
+  ],
+  [
+    "\\nvRightarrow",
+    "⤃  rightwards double arrow with vertical stroke"
+  ],
+  [
+    "\\nvLeftrightarrow",
+    "⤄  left right double arrow with vertical stroke"
+  ],
+  [
+    "\\twoheadmapsto",
+    "⤅  rightwards two-headed arrow from bar"
+  ],
+  [
+    "\\Mapsfrom",
+    "⤆ = \\mappedfrom (kpfonts), leftwards double arrow from bar"
+  ],
+  [
+    "\\Mapsto",
+    "⤇ rightwards double arrow from bar"
+  ],
+  [
+    "\\downarrowbarred",
+    "⤈  downwards arrow with horizontal stroke"
+  ],
+  [
+    "\\uparrowbarred",
+    "⤉  upwards arrow with horizontal stroke"
+  ],
+  [
+    "\\Uuparrow",
+    "⤊  upwards triple arrow"
+  ],
+  [
+    "\\Ddownarrow",
+    "⤋  downwards triple arrow"
+  ],
+  [
+    "\\leftbkarrow",
+    "⤌  leftwards double dash arrow"
+  ],
+  [
+    "\\rightbkarrow",
+    "⤍  rightwards double dash arrow"
+  ],
+  [
+    "\\leftdbkarrow",
+    "⤎  leftwards triple dash arrow"
+  ],
+  [
+    "\\dbkarow",
+    "⤏  rightwards triple dash arrow"
+  ],
+  [
+    "\\drbkarow",
+    "⤐  rightwards two-headed triple dash arrow"
+  ],
+  [
+    "\\rightdotarrow",
+    "⤑  rightwards arrow with dotted stem"
+  ],
+  [
+    "\\UpArrowBar",
+    "⤒ upwards arrow to bar"
+  ],
+  [
+    "\\DownArrowBar",
+    "⤓ downwards arrow to bar"
+  ],
+  [
+    "\\pinj",
+    "⤔ rightwards arrow with tail with vertical stroke, z notation partial injection"
+  ],
+  [
+    "\\finj",
+    "⤕ rightwards arrow with tail with double vertical stroke, z notation finite injection"
+  ],
+  [
+    "\\bij",
+    "⤖ rightwards two-headed arrow with tail, z notation bijection"
+  ],
+  [
+    "\\nvtwoheadrightarrowtail",
+    "⤗  rightwards two-headed arrow with tail with vertical stroke, z notation surjective injection"
+  ],
+  [
+    "\\nVtwoheadrightarrowtail",
+    "⤘  rightwards two-headed arrow with tail with double vertical stroke, z notation finite surjective injection"
+  ],
+  [
+    "\\lefttail",
+    "⤙  leftwards arrow-tail"
+  ],
+  [
+    "\\righttail",
+    "⤚  rightwards arrow-tail"
+  ],
+  [
+    "\\leftdbltail",
+    "⤛  leftwards double arrow-tail"
+  ],
+  [
+    "\\rightdbltail",
+    "⤜  rightwards double arrow-tail"
+  ],
+  [
+    "\\diamondleftarrow",
+    "⤝  leftwards arrow to black diamond"
+  ],
+  [
+    "\\rightarrowdiamond",
+    "⤞  rightwards arrow to black diamond"
+  ],
+  [
+    "\\diamondleftarrowbar",
+    "⤟  leftwards arrow from bar to black diamond"
+  ],
+  [
+    "\\barrightarrowdiamond",
+    "⤠  rightwards arrow from bar to black diamond"
+  ],
+  [
+    "\\nwsearrow",
+    "⤡  north west and south east arrow"
+  ],
+  [
+    "\\neswarrow",
+    "⤢  north east and south west arrow"
+  ],
+  [
+    "\\hknwarrow",
+    "⤣  north west arrow with hook"
+  ],
+  [
+    "\\hknearrow",
+    "⤤  north east arrow with hook"
+  ],
+  [
+    "\\hksearow",
+    "⤥  south east arrow with hook"
+  ],
+  [
+    "\\hkswarow",
+    "⤦  south west arrow with hook"
+  ],
+  [
+    "\\tona",
+    "⤧  north west arrow and north east arrow"
+  ],
+  [
+    "\\toea",
+    "⤨  north east arrow and south east arrow"
+  ],
+  [
+    "\\tosa",
+    "⤩  south east arrow and south west arrow"
+  ],
+  [
+    "\\towa",
+    "⤪  south west arrow and north west arrow"
+  ],
+  [
+    "\\rdiagovfdiag",
+    "⤫  rising diagonal crossing falling diagonal"
+  ],
+  [
+    "\\fdiagovrdiag",
+    "⤬  falling diagonal crossing rising diagonal"
+  ],
+  [
+    "\\seovnearrow",
+    "⤭  south east arrow crossing north east arrow"
+  ],
+  [
+    "\\neovsearrow",
+    "⤮  north east arrow crossing south east arrow"
+  ],
+  [
+    "\\fdiagovnearrow",
+    "⤯  falling diagonal crossing north east arrow"
+  ],
+  [
+    "\\rdiagovsearrow",
+    "⤰  rising diagonal crossing south east arrow"
+  ],
+  [
+    "\\neovnwarrow",
+    "⤱  north east arrow crossing north west arrow"
+  ],
+  [
+    "\\nwovnearrow",
+    "⤲  north west arrow crossing north east arrow"
+  ],
+  [
+    "\\leadsto",
+    "⤳ wave arrow pointing directly right"
+  ],
+  [
+    "\\uprightcurvearrow",
+    "⤴  arrow pointing rightwards then curving upwards"
+  ],
+  [
+    "\\downrightcurvedarrow",
+    "⤵  arrow pointing rightwards then curving downwards"
+  ],
+  [
+    "\\leftdowncurvedarrow",
+    "⤶  arrow pointing downwards then curving leftwards"
+  ],
+  [
+    "\\rightdowncurvedarrow",
+    "⤷  arrow pointing downwards then curving rightwards"
+  ],
+  [
+    "\\cwrightarcarrow",
+    "⤸  right-side arc clockwise arrow"
+  ],
+  [
+    "\\acwleftarcarrow",
+    "⤹  left-side arc anticlockwise arrow"
+  ],
+  [
+    "\\acwoverarcarrow",
+    "⤺  top arc anticlockwise arrow"
+  ],
+  [
+    "\\acwunderarcarrow",
+    "⤻  bottom arc anticlockwise arrow"
+  ],
+  [
+    "\\curvearrowrightminus",
+    "⤼  top arc clockwise arrow with minus"
+  ],
+  [
+    "\\curvearrowleftplus",
+    "⤽  top arc anticlockwise arrow with plus"
+  ],
+  [
+    "\\cwundercurvearrow",
+    "⤾  lower right semicircular clockwise arrow"
+  ],
+  [
+    "\\ccwundercurvearrow",
+    "⤿  lower left semicircular anticlockwise arrow"
+  ],
+  [
+    "\\acwcirclearrow",
+    "⥀  anticlockwise closed circle arrow"
+  ],
+  [
+    "\\cwcirclearrow",
+    "⥁  clockwise closed circle arrow"
+  ],
+  [
+    "\\rightarrowshortleftarrow",
+    "⥂  rightwards arrow above short leftwards arrow"
+  ],
+  [
+    "\\leftarrowshortrightarrow",
+    "⥃  leftwards arrow above short rightwards arrow"
+  ],
+  [
+    "\\shortrightarrowleftarrow",
+    "⥄  short rightwards arrow above leftwards arrow"
+  ],
+  [
+    "\\rightarrowplus",
+    "⥅  rightwards arrow with plus below"
+  ],
+  [
+    "\\leftarrowplus",
+    "⥆  leftwards arrow with plus below"
+  ],
+  [
+    "\\rightarrowx",
+    "⥇  rightwards arrow through x"
+  ],
+  [
+    "\\leftrightarrowcircle",
+    "⥈  left right arrow through small circle"
+  ],
+  [
+    "\\twoheaduparrowcircle",
+    "⥉  upwards two-headed arrow from small circle"
+  ],
+  [
+    "\\leftrightharpoon",
+    "⥊ left barb up right barb down harpoon"
+  ],
+  [
+    "\\rightleftharpoon",
+    "⥋ left barb down right barb up harpoon"
+  ],
+  [
+    "\\updownharpoonrightleft",
+    "⥌  up barb right down barb left harpoon"
+  ],
+  [
+    "\\updownharpoonleftright",
+    "⥍  up barb left down barb right harpoon"
+  ],
+  [
+    "\\leftrightharpoonup",
+    "⥎ left barb up right barb up harpoon"
+  ],
+  [
+    "\\rightupdownharpoon",
+    "⥏ up barb right down barb right harpoon"
+  ],
+  [
+    "\\leftrightharpoondown",
+    "⥐ left barb down right barb down harpoon"
+  ],
+  [
+    "\\leftupdownharpoon",
+    "⥑ up barb left down barb left harpoon"
+  ],
+  [
+    "\\LeftVectorBar",
+    "⥒ leftwards harpoon with barb up to bar"
+  ],
+  [
+    "\\RightVectorBar",
+    "⥓ rightwards harpoon with barb up to bar"
+  ],
+  [
+    "\\RightUpVectorBar",
+    "⥔ upwards harpoon with barb right to bar"
+  ],
+  [
+    "\\RightDownVectorBar",
+    "⥕ downwards harpoon with barb right to bar"
+  ],
+  [
+    "\\DownLeftVectorBar",
+    "⥖ leftwards harpoon with barb down to bar"
+  ],
+  [
+    "\\DownRightVectorBar",
+    "⥗ rightwards harpoon with barb down to bar"
+  ],
+  [
+    "\\LeftUpVectorBar",
+    "⥘ upwards harpoon with barb left to bar"
+  ],
+  [
+    "\\LeftDownVectorBar",
+    "⥙ downwards harpoon with barb left to bar"
+  ],
+  [
+    "\\LeftTeeVector",
+    "⥚ leftwards harpoon with barb up from bar"
+  ],
+  [
+    "\\RightTeeVector",
+    "⥛ rightwards harpoon with barb up from bar"
+  ],
+  [
+    "\\RightUpTeeVector",
+    "⥜ upwards harpoon with barb right from bar"
+  ],
+  [
+    "\\RightDownTeeVector",
+    "⥝ downwards harpoon with barb right from bar"
+  ],
+  [
+    "\\DownLeftTeeVector",
+    "⥞ leftwards harpoon with barb down from bar"
+  ],
+  [
+    "\\DownRightTeeVector",
+    "⥟ rightwards harpoon with barb down from bar"
+  ],
+  [
+    "\\LeftUpTeeVector",
+    "⥠ upwards harpoon with barb left from bar"
+  ],
+  [
+    "\\LeftDownTeeVector",
+    "⥡ downwards harpoon with barb left from bar"
+  ],
+  [
+    "\\leftleftharpoons",
+    "⥢ leftwards harpoon with barb up above leftwards harpoon with barb down"
+  ],
+  [
+    "\\upupharpoons",
+    "⥣ upwards harpoon with barb left beside upwards harpoon with barb right"
+  ],
+  [
+    "\\rightrightharpoons",
+    "⥤ rightwards harpoon with barb up above rightwards harpoon with barb down"
+  ],
+  [
+    "\\downdownharpoons",
+    "⥥ downwards harpoon with barb left beside downwards harpoon with barb right"
+  ],
+  [
+    "\\leftrightharpoonsup",
+    "⥦  leftwards harpoon with barb up above rightwards harpoon with barb up"
+  ],
+  [
+    "\\leftrightharpoonsdown",
+    "⥧  leftwards harpoon with barb down above rightwards harpoon with barb down"
+  ],
+  [
+    "\\rightleftharpoonsup",
+    "⥨  rightwards harpoon with barb up above leftwards harpoon with barb up"
+  ],
+  [
+    "\\rightleftharpoonsdown",
+    "⥩  rightwards harpoon with barb down above leftwards harpoon with barb down"
+  ],
+  [
+    "\\leftbarharpoon",
+    "⥪ leftwards harpoon with barb up above long dash"
+  ],
+  [
+    "\\barleftharpoon",
+    "⥫ leftwards harpoon with barb down below long dash"
+  ],
+  [
+    "\\rightbarharpoon",
+    "⥬ rightwards harpoon with barb up above long dash"
+  ],
+  [
+    "\\barrightharpoon",
+    "⥭ rightwards harpoon with barb down below long dash"
+  ],
+  [
+    "\\updownharpoons",
+    "⥮ = \\upequilibrium (wrisym), upwards harpoon with barb left beside downwards harpoon with barb right"
+  ],
+  [
+    "\\downupharpoons",
+    "⥯ = \\uprevequilibrium (wrisym), downwards harpoon with barb left beside upwards harpoon with barb right"
+  ],
+  [
+    "\\rightimply",
+    "⥰  right double arrow with rounded head"
+  ],
+  [
+    "\\equalrightarrow",
+    "⥱  equals sign above rightwards arrow"
+  ],
+  [
+    "\\similarrightarrow",
+    "⥲  tilde operator above rightwards arrow"
+  ],
+  [
+    "\\leftarrowsimilar",
+    "⥳  leftwards arrow above tilde operator"
+  ],
+  [
+    "\\rightarrowsimilar",
+    "⥴  rightwards arrow above tilde operator"
+  ],
+  [
+    "\\rightarrowapprox",
+    "⥵  rightwards arrow above almost equal to"
+  ],
+  [
+    "\\ltlarr",
+    "⥶  less-than above leftwards arrow"
+  ],
+  [
+    "\\leftarrowless",
+    "⥷  leftwards arrow through less-than"
+  ],
+  [
+    "\\gtrarr",
+    "⥸  greater-than above rightwards arrow"
+  ],
+  [
+    "\\subrarr",
+    "⥹  subset above rightwards arrow"
+  ],
+  [
+    "\\leftarrowsubset",
+    "⥺  leftwards arrow through subset"
+  ],
+  [
+    "\\suplarr",
+    "⥻  superset above leftwards arrow"
+  ],
+  [
+    "\\strictfi",
+    "⥼ left fish tail"
+  ],
+  [
+    "\\strictif",
+    "⥽ right fish tail"
+  ],
+  [
+    "\\upfishtail",
+    "⥾  up fish tail"
+  ],
+  [
+    "\\downfishtail",
+    "⥿  down fish tail"
+  ],
+  [
+    "\\VERT",
+    "⦀ triple vertical bar delimiter"
+  ],
+  [
+    "\\spot",
+    "⦁ = \\dot (oz), z notation spot"
+  ],
+  [
+    "\\typecolon",
+    "⦂  z notation type colon, (present in bbold font but no command)"
+  ],
+  [
+    "\\lBrace",
+    "⦃  left white curly bracket"
+  ],
+  [
+    "\\rBrace",
+    "⦄  right white curly bracket"
+  ],
+  [
+    "\\Lparen",
+    "⦅ left white parenthesis"
+  ],
+  [
+    "\\Rparen",
+    "⦆ right white parenthesis"
+  ],
+  [
+    "\\limg",
+    "⦇ = \\llparenthesis (stmaryrd), z notation left image bracket"
+  ],
+  [
+    "\\rimg",
+    "⦈ = \\rrparenthesis (stmaryrd), z notation right image bracket"
+  ],
+  [
+    "\\lblot",
+    "⦉ z notation left binding bracket"
+  ],
+  [
+    "\\rblot",
+    "⦊ z notation right binding bracket"
+  ],
+  [
+    "\\lbrackubar",
+    "⦋  left square bracket with underbar"
+  ],
+  [
+    "\\rbrackubar",
+    "⦌  right square bracket with underbar"
+  ],
+  [
+    "\\lbrackultick",
+    "⦍  left square bracket with tick in top corner"
+  ],
+  [
+    "\\rbracklrtick",
+    "⦎  right square bracket with tick in bottom corner"
+  ],
+  [
+    "\\lbracklltick",
+    "⦏  left square bracket with tick in bottom corner"
+  ],
+  [
+    "\\rbrackurtick",
+    "⦐  right square bracket with tick in top corner"
+  ],
+  [
+    "\\langledot",
+    "⦑  left angle bracket with dot"
+  ],
+  [
+    "\\rangledot",
+    "⦒  right angle bracket with dot"
+  ],
+  [
+    "\\lparenless",
+    "⦓  left arc less-than bracket"
+  ],
+  [
+    "\\rparengtr",
+    "⦔  right arc greater-than bracket"
+  ],
+  [
+    "\\Lparengtr",
+    "⦕  double left arc greater-than bracket"
+  ],
+  [
+    "\\Rparenless",
+    "⦖  double right arc less-than bracket"
+  ],
+  [
+    "\\lblkbrbrak",
+    "⦗  left black tortoise shell bracket"
+  ],
+  [
+    "\\rblkbrbrak",
+    "⦘  right black tortoise shell bracket"
+  ],
+  [
+    "\\fourvdots",
+    "⦙  dotted fence"
+  ],
+  [
+    "\\vzigzag",
+    "⦚  vertical zigzag line"
+  ],
+  [
+    "\\measuredangleleft",
+    "⦛  measured angle opening left"
+  ],
+  [
+    "\\rightanglesqr",
+    "⦜  right angle variant with square"
+  ],
+  [
+    "\\rightanglemdot",
+    "⦝  measured right angle with dot"
+  ],
+  [
+    "\\angles",
+    "⦞  angle with s inside"
+  ],
+  [
+    "\\angdnr",
+    "⦟  acute angle"
+  ],
+  [
+    "\\gtlpar",
+    "⦠  spherical angle opening left"
+  ],
+  [
+    "\\sphericalangleup",
+    "⦡  spherical angle opening up"
+  ],
+  [
+    "\\turnangle",
+    "⦢  turned angle"
+  ],
+  [
+    "\\revangle",
+    "⦣  reversed angle"
+  ],
+  [
+    "\\angleubar",
+    "⦤  angle with underbar"
+  ],
+  [
+    "\\revangleubar",
+    "⦥  reversed angle with underbar"
+  ],
+  [
+    "\\wideangledown",
+    "⦦  oblique angle opening up"
+  ],
+  [
+    "\\wideangleup",
+    "⦧  oblique angle opening down"
+  ],
+  [
+    "\\measanglerutone",
+    "⦨  measured angle with open arm ending in arrow pointing up and right"
+  ],
+  [
+    "\\measanglelutonw",
+    "⦩  measured angle with open arm ending in arrow pointing up and left"
+  ],
+  [
+    "\\measanglerdtose",
+    "⦪  measured angle with open arm ending in arrow pointing down and right"
+  ],
+  [
+    "\\measangleldtosw",
+    "⦫  measured angle with open arm ending in arrow pointing down and left"
+  ],
+  [
+    "\\measangleurtone",
+    "⦬  measured angle with open arm ending in arrow pointing right and up"
+  ],
+  [
+    "\\measangleultonw",
+    "⦭  measured angle with open arm ending in arrow pointing left and up"
+  ],
+  [
+    "\\measangledrtose",
+    "⦮  measured angle with open arm ending in arrow pointing right and down"
+  ],
+  [
+    "\\measangledltosw",
+    "⦯  measured angle with open arm ending in arrow pointing left and down"
+  ],
+  [
+    "\\revemptyset",
+    "⦰  reversed empty set"
+  ],
+  [
+    "\\emptysetobar",
+    "⦱  empty set with overbar"
+  ],
+  [
+    "\\emptysetocirc",
+    "⦲  empty set with small circle above"
+  ],
+  [
+    "\\emptysetoarr",
+    "⦳  empty set with right arrow above"
+  ],
+  [
+    "\\emptysetoarrl",
+    "⦴  empty set with left arrow above"
+  ],
+  [
+    "\\circlehbar",
+    "⦵  circle with horizontal bar"
+  ],
+  [
+    "\\circledvert",
+    "⦶  circled vertical bar"
+  ],
+  [
+    "\\circledparallel",
+    "⦷  circled parallel"
+  ],
+  [
+    "\\circledbslash",
+    "⦸ circled reverse solidus"
+  ],
+  [
+    "\\operp",
+    "⦹  circled perpendicular"
+  ],
+  [
+    "\\obot",
+    "⦺  circle divided by horizontal bar and top half divided by vertical bar"
+  ],
+  [
+    "\\olcross",
+    "⦻  circle with superimposed x"
+  ],
+  [
+    "\\odotslashdot",
+    "⦼  circled anticlockwise-rotated division sign"
+  ],
+  [
+    "\\uparrowoncircle",
+    "⦽  up arrow through circle"
+  ],
+  [
+    "\\circledwhitebullet",
+    "⦾  circled white bullet"
+  ],
+  [
+    "\\circledbullet",
+    "⦿  circled bullet"
+  ],
+  [
+    "\\circledless",
+    "⧀ circled less-than"
+  ],
+  [
+    "\\circledgtr",
+    "⧁ circled greater-than"
+  ],
+  [
+    "\\cirscir",
+    "⧂  circle with small circle to the right"
+  ],
+  [
+    "\\cirE",
+    "⧃  circle with two horizontal strokes to the right"
+  ],
+  [
+    "\\boxslash",
+    "⧄ squared rising diagonal slash"
+  ],
+  [
+    "\\boxbslash",
+    "⧅ squared falling diagonal slash"
+  ],
+  [
+    "\\boxast",
+    "⧆ squared asterisk"
+  ],
+  [
+    "\\boxcircle",
+    "⧇ squared small circle"
+  ],
+  [
+    "\\boxbox",
+    "⧈ squared square"
+  ],
+  [
+    "\\boxonbox",
+    "⧉  two joined squares"
+  ],
+  [
+    "\\triangleodot",
+    "⧊  triangle with dot above"
+  ],
+  [
+    "\\triangleubar",
+    "⧋  triangle with underbar"
+  ],
+  [
+    "\\triangles",
+    "⧌  s in triangle"
+  ],
+  [
+    "\\triangleserifs",
+    "⧍  triangle with serifs at bottom"
+  ],
+  [
+    "\\rtriltri",
+    "⧎  right triangle above left triangle"
+  ],
+  [
+    "\\LeftTriangleBar",
+    "⧏ left triangle beside vertical bar"
+  ],
+  [
+    "\\RightTriangleBar",
+    "⧐ vertical bar beside right triangle"
+  ],
+  [
+    "\\lfbowtie",
+    "⧑  left black bowtie"
+  ],
+  [
+    "\\rfbowtie",
+    "⧒  right black bowtie"
+  ],
+  [
+    "\\fbowtie",
+    "⧓  black bowtie"
+  ],
+  [
+    "\\lftimes",
+    "⧔  left black times"
+  ],
+  [
+    "\\rftimes",
+    "⧕  right black times"
+  ],
+  [
+    "\\hourglass",
+    "⧖  white hourglass"
+  ],
+  [
+    "\\blackhourglass",
+    "⧗  black hourglass"
+  ],
+  [
+    "\\lvzigzag",
+    "⧘  left wiggly fence"
+  ],
+  [
+    "\\rvzigzag",
+    "⧙  right wiggly fence"
+  ],
+  [
+    "\\Lvzigzag",
+    "⧚  left double wiggly fence"
+  ],
+  [
+    "\\Rvzigzag",
+    "⧛  right double wiggly fence"
+  ],
+  [
+    "\\iinfin",
+    "⧜  incomplete infinity"
+  ],
+  [
+    "\\tieinfty",
+    "⧝  tie over infinity"
+  ],
+  [
+    "\\nvinfty",
+    "⧞  infinity negated with vertical bar"
+  ],
+  [
+    "\\multimapboth",
+    "⧟ double-ended multimap"
+  ],
+  [
+    "\\laplac",
+    "⧠  square with contoured outline"
+  ],
+  [
+    "\\lrtriangleeq",
+    "⧡  increases as"
+  ],
+  [
+    "\\shuffle",
+    "⧢  shuffle product"
+  ],
+  [
+    "\\eparsl",
+    "⧣  equals sign and slanted parallel"
+  ],
+  [
+    "\\smeparsl",
+    "⧤  equals sign and slanted parallel with tilde above"
+  ],
+  [
+    "\\eqvparsl",
+    "⧥  identical to and slanted parallel"
+  ],
+  [
+    "\\gleichstark",
+    "⧦  gleich stark"
+  ],
+  [
+    "\\thermod",
+    "⧧  thermodynamic"
+  ],
+  [
+    "\\downtriangleleftblack",
+    "⧨  down-pointing triangle with left half black"
+  ],
+  [
+    "\\downtrianglerightblack",
+    "⧩  down-pointing triangle with right half black"
+  ],
+  [
+    "\\blackdiamonddownarrow",
+    "⧪  black diamond with down arrow"
+  ],
+  [
+    "\\blacklozenge",
+    "⧫ black lozenge"
+  ],
+  [
+    "\\circledownarrow",
+    "⧬  white circle with down arrow"
+  ],
+  [
+    "\\blackcircledownarrow",
+    "⧭  black circle with down arrow"
+  ],
+  [
+    "\\errbarsquare",
+    "⧮  error-barred white square"
+  ],
+  [
+    "\\errbarblacksquare",
+    "⧯  error-barred black square"
+  ],
+  [
+    "\\errbardiamond",
+    "⧰  error-barred white diamond"
+  ],
+  [
+    "\\errbarblackdiamond",
+    "⧱  error-barred black diamond"
+  ],
+  [
+    "\\errbarcircle",
+    "⧲  error-barred white circle"
+  ],
+  [
+    "\\errbarblackcircle",
+    "⧳  error-barred black circle"
+  ],
+  [
+    "\\ruledelayed",
+    "⧴  rule-delayed"
+  ],
+  [
+    "\\setminus",
+    "⧵ reverse solidus operator"
+  ],
+  [
+    "\\dsol",
+    "⧶  solidus with overbar"
+  ],
+  [
+    "\\rsolbar",
+    "⧷  reverse solidus with horizontal stroke"
+  ],
+  [
+    "\\xsol",
+    "⧸  big solidus"
+  ],
+  [
+    "\\zhide",
+    "⧹ = \\hide (oz), big reverse solidus, z notation schema hiding"
+  ],
+  [
+    "\\doubleplus",
+    "⧺  double plus"
+  ],
+  [
+    "\\tripleplus",
+    "⧻  triple plus"
+  ],
+  [
+    "\\lcurvyangle",
+    "⧼  left pointing curved angle bracket"
+  ],
+  [
+    "\\rcurvyangle",
+    "⧽  right pointing curved angle bracket"
+  ],
+  [
+    "\\tplus",
+    "⧾  tiny"
+  ],
+  [
+    "\\tminus",
+    "⧿  miny"
+  ],
+  [
+    "\\bigodot",
+    "⨀ n-ary circled dot operator"
+  ],
+  [
+    "\\bigoplus",
+    "⨁ n-ary circled plus operator"
+  ],
+  [
+    "\\bigotimes",
+    "⨂ n-ary circled times operator"
+  ],
+  [
+    "\\bigcupdot",
+    "⨃  n-ary union operator with dot"
+  ],
+  [
+    "\\biguplus",
+    "⨄ n-ary union operator with plus"
+  ],
+  [
+    "\\bigsqcap",
+    "⨅ n-ary square intersection operator"
+  ],
+  [
+    "\\bigsqcup",
+    "⨆ n-ary square union operator"
+  ],
+  [
+    "\\conjquant",
+    "⨇  two logical and operator"
+  ],
+  [
+    "\\disjquant",
+    "⨈  two logical or operator"
+  ],
+  [
+    "\\varprod",
+    "⨉ n-ary times operator"
+  ],
+  [
+    "\\modtwosum",
+    "⨊  modulo two sum"
+  ],
+  [
+    "\\sumint",
+    "⨋  summation with integral"
+  ],
+  [
+    "\\iiiint",
+    "⨌ quadruple integral operator"
+  ],
+  [
+    "\\intbar",
+    "⨍  finite part integral"
+  ],
+  [
+    "\\intBar",
+    "⨎  integral with double stroke"
+  ],
+  [
+    "\\fint",
+    "⨏ integral average with slash"
+  ],
+  [
+    "\\cirfnint",
+    "⨐  circulation function"
+  ],
+  [
+    "\\awint",
+    "⨑  anticlockwise integration"
+  ],
+  [
+    "\\rppolint",
+    "⨒  line integration with rectangular path around pole"
+  ],
+  [
+    "\\scpolint",
+    "⨓  line integration with semicircular path around pole"
+  ],
+  [
+    "\\npolint",
+    "⨔  line integration not including the pole"
+  ],
+  [
+    "\\pointint",
+    "⨕  integral around a point operator"
+  ],
+  [
+    "\\sqint",
+    "⨖ = \\sqrint (wrisym), quaternion integral operator"
+  ],
+  [
+    "\\intlarhk",
+    "⨗  integral with leftwards arrow with hook"
+  ],
+  [
+    "\\intx",
+    "⨘  integral with times sign"
+  ],
+  [
+    "\\intcap",
+    "⨙  integral with intersection"
+  ],
+  [
+    "\\intcup",
+    "⨚  integral with union"
+  ],
+  [
+    "\\upint",
+    "⨛  integral with overbar"
+  ],
+  [
+    "\\lowint",
+    "⨜  integral with underbar"
+  ],
+  [
+    "\\Join",
+    "⨝ join"
+  ],
+  [
+    "\\bigtriangleleft",
+    "⨞  large left triangle operator"
+  ],
+  [
+    "\\zcmp",
+    "⨟ = \\semi (oz), = \\fatsemi (stmaryrd), z notation schema composition"
+  ],
+  [
+    "\\zpipe",
+    "⨠ z notation schema piping"
+  ],
+  [
+    "\\zproject",
+    "⨡ = \\project (oz), z notation schema projection"
+  ],
+  [
+    "\\ringplus",
+    "⨢  plus sign with small circle above"
+  ],
+  [
+    "\\plushat",
+    "⨣  plus sign with circumflex accent above"
+  ],
+  [
+    "\\simplus",
+    "⨤  plus sign with tilde above"
+  ],
+  [
+    "\\plusdot",
+    "⨥  plus sign with dot below"
+  ],
+  [
+    "\\plussim",
+    "⨦  plus sign with tilde below"
+  ],
+  [
+    "\\plussubtwo",
+    "⨧  plus sign with subscript two"
+  ],
+  [
+    "\\plustrif",
+    "⨨  plus sign with black triangle"
+  ],
+  [
+    "\\commaminus",
+    "⨩  minus sign with comma above"
+  ],
+  [
+    "\\minusdot",
+    "⨪  minus sign with dot below"
+  ],
+  [
+    "\\minusfdots",
+    "⨫  minus sign with falling dots"
+  ],
+  [
+    "\\minusrdots",
+    "⨬  minus sign with rising dots"
+  ],
+  [
+    "\\opluslhrim",
+    "⨭  plus sign in left half circle"
+  ],
+  [
+    "\\oplusrhrim",
+    "⨮  plus sign in right half circle"
+  ],
+  [
+    "\\vectimes",
+    "⨯  # \\times, vector or cross product"
+  ],
+  [
+    "\\dottimes",
+    "⨰  multiplication sign with dot above"
+  ],
+  [
+    "\\timesbar",
+    "⨱  multiplication sign with underbar"
+  ],
+  [
+    "\\btimes",
+    "⨲  semidirect product with bottom closed"
+  ],
+  [
+    "\\smashtimes",
+    "⨳  smash product"
+  ],
+  [
+    "\\otimeslhrim",
+    "⨴  multiplication sign in left half circle"
+  ],
+  [
+    "\\otimesrhrim",
+    "⨵  multiplication sign in right half circle"
+  ],
+  [
+    "\\otimeshat",
+    "⨶  circled multiplication sign with circumflex accent"
+  ],
+  [
+    "\\Otimes",
+    "⨷  multiplication sign in double circle"
+  ],
+  [
+    "\\odiv",
+    "⨸  circled division sign"
+  ],
+  [
+    "\\triangleplus",
+    "⨹  plus sign in triangle"
+  ],
+  [
+    "\\triangleminus",
+    "⨺  minus sign in triangle"
+  ],
+  [
+    "\\triangletimes",
+    "⨻  multiplication sign in triangle"
+  ],
+  [
+    "\\intprod",
+    "⨼  interior product"
+  ],
+  [
+    "\\intprodr",
+    "⨽  righthand interior product"
+  ],
+  [
+    "\\fcmp",
+    "⨾ = \\comp (oz), z notation relational composition"
+  ],
+  [
+    "\\amalg",
+    "⨿ amalgamation or coproduct"
+  ],
+  [
+    "\\capdot",
+    "⩀  intersection with dot"
+  ],
+  [
+    "\\uminus",
+    "⩁  union with minus sign, z notation bag subtraction"
+  ],
+  [
+    "\\barcup",
+    "⩂  union with overbar"
+  ],
+  [
+    "\\barcap",
+    "⩃  intersection with overbar"
+  ],
+  [
+    "\\capwedge",
+    "⩄  intersection with logical and"
+  ],
+  [
+    "\\cupvee",
+    "⩅  union with logical or"
+  ],
+  [
+    "\\cupovercap",
+    "⩆  union above intersection"
+  ],
+  [
+    "\\capovercup",
+    "⩇  intersection above union"
+  ],
+  [
+    "\\cupbarcap",
+    "⩈  union above bar above intersection"
+  ],
+  [
+    "\\capbarcup",
+    "⩉  intersection above bar above union"
+  ],
+  [
+    "\\twocups",
+    "⩊  union beside and joined with union"
+  ],
+  [
+    "\\twocaps",
+    "⩋  intersection beside and joined with intersection"
+  ],
+  [
+    "\\closedvarcup",
+    "⩌  closed union with serifs"
+  ],
+  [
+    "\\closedvarcap",
+    "⩍  closed intersection with serifs"
+  ],
+  [
+    "\\Sqcap",
+    "⩎  double square intersection"
+  ],
+  [
+    "\\Sqcup",
+    "⩏  double square union"
+  ],
+  [
+    "\\closedvarcupsmashprod",
+    "⩐  closed union with serifs and smash product"
+  ],
+  [
+    "\\wedgeodot",
+    "⩑  logical and with dot above"
+  ],
+  [
+    "\\veeodot",
+    "⩒  logical or with dot above"
+  ],
+  [
+    "\\Wedge",
+    "⩓  double logical and"
+  ],
+  [
+    "\\Vee",
+    "⩔  double logical or"
+  ],
+  [
+    "\\wedgeonwedge",
+    "⩕  two intersecting logical and"
+  ],
+  [
+    "\\veeonvee",
+    "⩖  two intersecting logical or"
+  ],
+  [
+    "\\bigslopedvee",
+    "⩗  sloping large or"
+  ],
+  [
+    "\\bigslopedwedge",
+    "⩘  sloping large and"
+  ],
+  [
+    "\\veeonwedge",
+    "⩙  logical or overlapping logical and"
+  ],
+  [
+    "\\wedgemidvert",
+    "⩚  logical and with middle stem"
+  ],
+  [
+    "\\veemidvert",
+    "⩛  logical or with middle stem"
+  ],
+  [
+    "\\midbarwedge",
+    "⩜  ogical and with horizontal dash"
+  ],
+  [
+    "\\midbarvee",
+    "⩝  logical or with horizontal dash"
+  ],
+  [
+    "\\doublebarwedge",
+    "⩞ logical and with double overbar"
+  ],
+  [
+    "\\wedgebar",
+    "⩟  logical and with underbar"
+  ],
+  [
+    "\\wedgedoublebar",
+    "⩠  logical and with double underbar"
+  ],
+  [
+    "\\varveebar",
+    "⩡  small vee with underbar"
+  ],
+  [
+    "\\doublebarvee",
+    "⩢  logical or with double overbar"
+  ],
+  [
+    "\\veedoublebar",
+    "⩣  logical or with double underbar"
+  ],
+  [
+    "\\dsub",
+    "⩤ = \\ndres (oz), z notation domain antirestriction"
+  ],
+  [
+    "\\rsub",
+    "⩥ = \\nrres (oz), z notation range antirestriction"
+  ],
+  [
+    "\\eqdot",
+    "⩦  equals sign with dot below"
+  ],
+  [
+    "\\dotequiv",
+    "⩧  identical with dot above"
+  ],
+  [
+    "\\equivVert",
+    "⩨  triple horizontal bar with double vertical stroke"
+  ],
+  [
+    "\\equivVvert",
+    "⩩  triple horizontal bar with triple vertical stroke"
+  ],
+  [
+    "\\dotsim",
+    "⩪  tilde operator with dot above"
+  ],
+  [
+    "\\simrdots",
+    "⩫  tilde operator with rising dots"
+  ],
+  [
+    "\\simminussim",
+    "⩬  similar minus similar"
+  ],
+  [
+    "\\congdot",
+    "⩭  congruent with dot above"
+  ],
+  [
+    "\\asteq",
+    "⩮  equals with asterisk"
+  ],
+  [
+    "\\hatapprox",
+    "⩯  almost equal to with circumflex accent"
+  ],
+  [
+    "\\approxeqq",
+    "⩰  approximately equal or equal to"
+  ],
+  [
+    "\\eqqplus",
+    "⩱  equals sign above plus sign"
+  ],
+  [
+    "\\pluseqq",
+    "⩲  plus sign above equals sign"
+  ],
+  [
+    "\\eqqsim",
+    "⩳  equals sign above tilde operator"
+  ],
+  [
+    "\\Coloneqq",
+    "⩴ # ::=, x \\coloneq (txfonts), double colon equal"
+  ],
+  [
+    "\\Equal",
+    "⩵ # ==, two consecutive equals signs"
+  ],
+  [
+    "\\Same",
+    "⩶ # ===, three consecutive equals signs"
+  ],
+  [
+    "\\ddotseq",
+    "⩷  equals sign with two dots above and two dots below"
+  ],
+  [
+    "\\equivDD",
+    "⩸  equivalent with four dots above"
+  ],
+  [
+    "\\ltcir",
+    "⩹  less-than with circle inside"
+  ],
+  [
+    "\\gtcir",
+    "⩺  greater-than with circle inside"
+  ],
+  [
+    "\\ltquest",
+    "⩻  less-than with question mark above"
+  ],
+  [
+    "\\gtquest",
+    "⩼  greater-than with question mark above"
+  ],
+  [
+    "\\leqslant",
+    "⩽ less-than or slanted equal to"
+  ],
+  [
+    "\\geqslant",
+    "⩾ greater-than or slanted equal to"
+  ],
+  [
+    "\\lesdot",
+    "⩿  less-than or slanted equal to with dot inside"
+  ],
+  [
+    "\\gesdot",
+    "⪀  greater-than or slanted equal to with dot inside"
+  ],
+  [
+    "\\lesdoto",
+    "⪁  less-than or slanted equal to with dot above"
+  ],
+  [
+    "\\gesdoto",
+    "⪂  greater-than or slanted equal to with dot above"
+  ],
+  [
+    "\\lesdotor",
+    "⪃  less-than or slanted equal to with dot above right"
+  ],
+  [
+    "\\gesdotol",
+    "⪄  greater-than or slanted equal to with dot above left"
+  ],
+  [
+    "\\lessapprox",
+    "⪅ less-than or approximate"
+  ],
+  [
+    "\\gtrapprox",
+    "⪆ greater-than or approximate"
+  ],
+  [
+    "\\lneq",
+    "⪇ less-than and single-line not equal to"
+  ],
+  [
+    "\\gneq",
+    "⪈ greater-than and single-line not equal to"
+  ],
+  [
+    "\\lnapprox",
+    "⪉ less-than and not approximate"
+  ],
+  [
+    "\\gnapprox",
+    "⪊ greater-than and not approximate"
+  ],
+  [
+    "\\lesseqqgtr",
+    "⪋ less-than above double-line equal above greater-than"
+  ],
+  [
+    "\\gtreqqless",
+    "⪌ greater-than above double-line equal above less-than"
+  ],
+  [
+    "\\lsime",
+    "⪍  less-than above similar or equal"
+  ],
+  [
+    "\\gsime",
+    "⪎  greater-than above similar or equal"
+  ],
+  [
+    "\\lsimg",
+    "⪏  less-than above similar above greater-than"
+  ],
+  [
+    "\\gsiml",
+    "⪐  greater-than above similar above less-than"
+  ],
+  [
+    "\\lgE",
+    "⪑  less-than above greater-than above double-line equal"
+  ],
+  [
+    "\\glE",
+    "⪒  greater-than above less-than above double-line equal"
+  ],
+  [
+    "\\lesges",
+    "⪓  less-than above slanted equal above greater-than above slanted equal"
+  ],
+  [
+    "\\gesles",
+    "⪔  greater-than above slanted equal above less-than above slanted equal"
+  ],
+  [
+    "\\eqslantless",
+    "⪕ slanted equal to or less-than"
+  ],
+  [
+    "\\eqslantgtr",
+    "⪖ slanted equal to or greater-than"
+  ],
+  [
+    "\\elsdot",
+    "⪗  slanted equal to or less-than with dot inside"
+  ],
+  [
+    "\\egsdot",
+    "⪘  slanted equal to or greater-than with dot inside"
+  ],
+  [
+    "\\eqqless",
+    "⪙  double-line equal to or less-than"
+  ],
+  [
+    "\\eqqgtr",
+    "⪚  double-line equal to or greater-than"
+  ],
+  [
+    "\\eqqslantless",
+    "⪛  double-line slanted equal to or less-than"
+  ],
+  [
+    "\\eqqslantgtr",
+    "⪜  double-line slanted equal to or greater-than"
+  ],
+  [
+    "\\simless",
+    "⪝  similar or less-than"
+  ],
+  [
+    "\\simgtr",
+    "⪞  similar or greater-than"
+  ],
+  [
+    "\\simlE",
+    "⪟  similar above less-than above equals sign"
+  ],
+  [
+    "\\simgE",
+    "⪠  similar above greater-than above equals sign"
+  ],
+  [
+    "\\NestedLessLess",
+    "⪡ = \\lll (mathabx -amssymb), double nested less-than"
+  ],
+  [
+    "\\NestedGreaterGreater",
+    "⪢ = \\ggg (mathabx -amssymb), double nested greater-than"
+  ],
+  [
+    "\\partialmeetcontraction",
+    "⪣  double less-than with underbar"
+  ],
+  [
+    "\\glj",
+    "⪤  greater-than overlapping less-than"
+  ],
+  [
+    "\\gla",
+    "⪥  greater-than beside less-than"
+  ],
+  [
+    "\\leftslice",
+    "⪦ less-than closed by curve"
+  ],
+  [
+    "\\rightslice",
+    "⪧ greater-than closed by curve"
+  ],
+  [
+    "\\lescc",
+    "⪨  less-than closed by curve above slanted equal"
+  ],
+  [
+    "\\gescc",
+    "⪩  greater-than closed by curve above slanted equal"
+  ],
+  [
+    "\\smt",
+    "⪪  smaller than"
+  ],
+  [
+    "\\lat",
+    "⪫  larger than"
+  ],
+  [
+    "\\smte",
+    "⪬  smaller than or equal to"
+  ],
+  [
+    "\\late",
+    "⪭  larger than or equal to"
+  ],
+  [
+    "\\bumpeqq",
+    "⪮  equals sign with bumpy above"
+  ],
+  [
+    "\\preceq",
+    "⪯ precedes above single-line equals sign"
+  ],
+  [
+    "\\succeq",
+    "⪰ succeeds above single-line equals sign"
+  ],
+  [
+    "\\precneq",
+    "⪱  precedes above single-line not equal to"
+  ],
+  [
+    "\\succneq",
+    "⪲  succeeds above single-line not equal to"
+  ],
+  [
+    "\\preceqq",
+    "⪳ precedes above equals sign"
+  ],
+  [
+    "\\succeqq",
+    "⪴ succeeds above equals sign"
+  ],
+  [
+    "\\precneqq",
+    "⪵  precedes above not equal to"
+  ],
+  [
+    "\\succneqq",
+    "⪶  succeeds above not equal to"
+  ],
+  [
+    "\\precapprox",
+    "⪷ precedes above almost equal to"
+  ],
+  [
+    "\\succapprox",
+    "⪸ succeeds above almost equal to"
+  ],
+  [
+    "\\precnapprox",
+    "⪹ precedes above not almost equal to"
+  ],
+  [
+    "\\succnapprox",
+    "⪺ succeeds above not almost equal to"
+  ],
+  [
+    "\\llcurly",
+    "⪻ double precedes"
+  ],
+  [
+    "\\ggcurly",
+    "⪼ double succeeds"
+  ],
+  [
+    "\\subsetdot",
+    "⪽  subset with dot"
+  ],
+  [
+    "\\supsetdot",
+    "⪾  superset with dot"
+  ],
+  [
+    "\\subsetplus",
+    "⪿  subset with plus sign below"
+  ],
+  [
+    "\\supsetplus",
+    "⫀  superset with plus sign below"
+  ],
+  [
+    "\\submult",
+    "⫁  subset with multiplication sign below"
+  ],
+  [
+    "\\supmult",
+    "⫂  superset with multiplication sign below"
+  ],
+  [
+    "\\subedot",
+    "⫃  subset of or equal to with dot above"
+  ],
+  [
+    "\\supedot",
+    "⫄  superset of or equal to with dot above"
+  ],
+  [
+    "\\subseteqq",
+    "⫅ subset of above equals sign"
+  ],
+  [
+    "\\supseteqq",
+    "⫆ superset of above equals sign"
+  ],
+  [
+    "\\subsim",
+    "⫇  subset of above tilde operator"
+  ],
+  [
+    "\\supsim",
+    "⫈  superset of above tilde operator"
+  ],
+  [
+    "\\subsetapprox",
+    "⫉  subset of above almost equal to"
+  ],
+  [
+    "\\supsetapprox",
+    "⫊  superset of above almost equal to"
+  ],
+  [
+    "\\subsetneqq",
+    "⫋ subset of above not equal to"
+  ],
+  [
+    "\\supsetneqq",
+    "⫌ superset of above not equal to"
+  ],
+  [
+    "\\lsqhook",
+    "⫍  square left open box operator"
+  ],
+  [
+    "\\rsqhook",
+    "⫎  square right open box operator"
+  ],
+  [
+    "\\csub",
+    "⫏  closed subset"
+  ],
+  [
+    "\\csup",
+    "⫐  closed superset"
+  ],
+  [
+    "\\csube",
+    "⫑  closed subset or equal to"
+  ],
+  [
+    "\\csupe",
+    "⫒  closed superset or equal to"
+  ],
+  [
+    "\\subsup",
+    "⫓  subset above superset"
+  ],
+  [
+    "\\supsub",
+    "⫔  superset above subset"
+  ],
+  [
+    "\\subsub",
+    "⫕  subset above subset"
+  ],
+  [
+    "\\supsup",
+    "⫖  superset above superset"
+  ],
+  [
+    "\\suphsub",
+    "⫗  superset beside subset"
+  ],
+  [
+    "\\supdsub",
+    "⫘  superset beside and joined by dash with subset"
+  ],
+  [
+    "\\forkv",
+    "⫙  element of opening downwards"
+  ],
+  [
+    "\\topfork",
+    "⫚  pitchfork with tee top"
+  ],
+  [
+    "\\mlcp",
+    "⫛  transversal intersection"
+  ],
+  [
+    "\\forks",
+    "⫝̸  forking"
+  ],
+  [
+    "\\forksnot",
+    "⫝  nonforking"
+  ],
+  [
+    "\\shortlefttack",
+    "⫞  short left tack"
+  ],
+  [
+    "\\shortdowntack",
+    "⫟  short down tack"
+  ],
+  [
+    "\\shortuptack",
+    "⫠  short up tack"
+  ],
+  [
+    "\\perps",
+    "⫡  perpendicular with s"
+  ],
+  [
+    "\\vDdash",
+    "⫢  vertical bar triple right turnstile"
+  ],
+  [
+    "\\dashV",
+    "⫣  double vertical bar left turnstile"
+  ],
+  [
+    "\\Dashv",
+    "⫤  vertical bar double left turnstile"
+  ],
+  [
+    "\\DashV",
+    "⫥  double vertical bar double left turnstile"
+  ],
+  [
+    "\\varVdash",
+    "⫦  long dash from left member of double vertical"
+  ],
+  [
+    "\\Barv",
+    "⫧  short down tack with overbar"
+  ],
+  [
+    "\\vBar",
+    "⫨  short up tack with underbar"
+  ],
+  [
+    "\\vBarv",
+    "⫩  short up tack above short down tack"
+  ],
+  [
+    "\\Top",
+    "⫪ double down tack"
+  ],
+  [
+    "\\Bot",
+    "⫫ = \\perp (txfonts), double up tack"
+  ],
+  [
+    "\\Not",
+    "⫬  double stroke not sign"
+  ],
+  [
+    "\\bNot",
+    "⫭  reversed double stroke not sign"
+  ],
+  [
+    "\\revnmid",
+    "⫮  does not divide with reversed negation slash"
+  ],
+  [
+    "\\cirmid",
+    "⫯  vertical line with circle above"
+  ],
+  [
+    "\\midcir",
+    "⫰  vertical line with circle below"
+  ],
+  [
+    "\\topcir",
+    "⫱  down tack with circle below"
+  ],
+  [
+    "\\nhpar",
+    "⫲  parallel with horizontal stroke"
+  ],
+  [
+    "\\parsim",
+    "⫳  parallel with tilde operator"
+  ],
+  [
+    "\\interleave",
+    "⫴ triple vertical bar binary relation"
+  ],
+  [
+    "\\nhVvert",
+    "⫵  triple vertical bar with horizontal stroke"
+  ],
+  [
+    "\\threedotcolon",
+    "⫶  triple colon operator"
+  ],
+  [
+    "\\lllnest",
+    "⫷  triple nested less-than"
+  ],
+  [
+    "\\gggnest",
+    "⫸  triple nested greater-than"
+  ],
+  [
+    "\\leqqslant",
+    "⫹  double-line slanted less-than or equal to"
+  ],
+  [
+    "\\geqqslant",
+    "⫺  double-line slanted greater-than or equal to"
+  ],
+  [
+    "\\trslash",
+    "⫻  triple solidus binary relation"
+  ],
+  [
+    "\\biginterleave",
+    "⫼ large triple vertical bar operator"
+  ],
+  [
+    "\\sslash",
+    "⫽ # \\varparallel (txfonts), double solidus operator"
+  ],
+  [
+    "\\talloblong",
+    "⫾ white vertical bar"
+  ],
+  [
+    "\\bigtalloblong",
+    "⫿  n-ary white vertical bar"
+  ],
+  [
+    "\\squaretopblack",
+    "⬒  square with top half black"
+  ],
+  [
+    "\\squarebotblack",
+    "⬓  square with bottom half black"
+  ],
+  [
+    "\\squareurblack",
+    "⬔  square with upper right diagonal half black"
+  ],
+  [
+    "\\squarellblack",
+    "⬕  square with lower left diagonal half black"
+  ],
+  [
+    "\\diamondleftblack",
+    "⬖  diamond with left half black"
+  ],
+  [
+    "\\diamondrightblack",
+    "⬗  diamond with right half black"
+  ],
+  [
+    "\\diamondtopblack",
+    "⬘  diamond with top half black"
+  ],
+  [
+    "\\diamondbotblack",
+    "⬙  diamond with bottom half black"
+  ],
+  [
+    "\\dottedsquare",
+    "⬚  dotted square"
+  ],
+  [
+    "\\blacksquare",
+    "⬛ black large square"
+  ],
+  [
+    "\\square",
+    "⬜ white large square"
+  ],
+  [
+    "\\vysmblksquare",
+    "⬝  # \\centerdot (amssymb), t \\squaredot (marvosym), black very small square"
+  ],
+  [
+    "\\vysmwhtsquare",
+    "⬞  white very small square"
+  ],
+  [
+    "\\pentagonblack",
+    "⬟  black pentagon"
+  ],
+  [
+    "\\pentagon",
+    "⬠  white pentagon"
+  ],
+  [
+    "\\varhexagon",
+    "⬡  white hexagon"
+  ],
+  [
+    "\\varhexagonblack",
+    "⬢  black hexagon"
+  ],
+  [
+    "\\hexagonblack",
+    "⬣  horizontal black hexagon"
+  ],
+  [
+    "\\lgblkcircle",
+    "⬤  black large circle"
+  ],
+  [
+    "\\mdblkdiamond",
+    "⬥  black medium diamond"
+  ],
+  [
+    "\\mdwhtdiamond",
+    "⬦  white medium diamond"
+  ],
+  [
+    "\\mdblklozenge",
+    "⬧  # \\blacklozenge (amssymb), black medium lozenge"
+  ],
+  [
+    "\\mdwhtlozenge",
+    "⬨  # \\lozenge (amssymb), white medium lozenge"
+  ],
+  [
+    "\\smblkdiamond",
+    "⬩  black small diamond"
+  ],
+  [
+    "\\smblklozenge",
+    "⬪  black small lozenge"
+  ],
+  [
+    "\\smwhtlozenge",
+    "⬫  white small lozenge"
+  ],
+  [
+    "\\blkhorzoval",
+    "⬬  black horizontal ellipse"
+  ],
+  [
+    "\\whthorzoval",
+    "⬭  white horizontal ellipse"
+  ],
+  [
+    "\\blkvertoval",
+    "⬮  black vertical ellipse"
+  ],
+  [
+    "\\whtvertoval",
+    "⬯  white vertical ellipse"
+  ],
+  [
+    "\\circleonleftarrow",
+    "⬰  left arrow with small circle"
+  ],
+  [
+    "\\leftthreearrows",
+    "⬱  three leftwards arrows"
+  ],
+  [
+    "\\leftarrowonoplus",
+    "⬲  left arrow with circled plus"
+  ],
+  [
+    "\\longleftsquigarrow",
+    "⬳  long leftwards squiggle arrow"
+  ],
+  [
+    "\\nvtwoheadleftarrow",
+    "⬴  leftwards two-headed arrow with vertical stroke"
+  ],
+  [
+    "\\nVtwoheadleftarrow",
+    "⬵  leftwards two-headed arrow with double vertical stroke"
+  ],
+  [
+    "\\twoheadmapsfrom",
+    "⬶  leftwards two-headed arrow from bar"
+  ],
+  [
+    "\\twoheadleftdbkarrow",
+    "⬷  leftwards two-headed triple-dash arrow"
+  ],
+  [
+    "\\leftdotarrow",
+    "⬸  leftwards arrow with dotted stem"
+  ],
+  [
+    "\\nvleftarrowtail",
+    "⬹  leftwards arrow with tail with vertical stroke"
+  ],
+  [
+    "\\nVleftarrowtail",
+    "⬺  leftwards arrow with tail with double vertical stroke"
+  ],
+  [
+    "\\twoheadleftarrowtail",
+    "⬻  leftwards two-headed arrow with tail"
+  ],
+  [
+    "\\nvtwoheadleftarrowtail",
+    "⬼  leftwards two-headed arrow with tail with vertical stroke"
+  ],
+  [
+    "\\nVtwoheadleftarrowtail",
+    "⬽  leftwards two-headed arrow with tail with double vertical stroke"
+  ],
+  [
+    "\\leftarrowx",
+    "⬾  leftwards arrow through x"
+  ],
+  [
+    "\\leftcurvedarrow",
+    "⬿  wave arrow pointing directly left"
+  ],
+  [
+    "\\equalleftarrow",
+    "⭀  equals sign above leftwards arrow"
+  ],
+  [
+    "\\bsimilarleftarrow",
+    "⭁  reverse tilde operator above leftwards arrow"
+  ],
+  [
+    "\\leftarrowbackapprox",
+    "⭂  leftwards arrow above reverse almost equal to"
+  ],
+  [
+    "\\rightarrowgtr",
+    "⭃  rightwards arrow through less-than"
+  ],
+  [
+    "\\rightarrowsupset",
+    "⭄  rightwards arrow through subset"
+  ],
+  [
+    "\\LLeftarrow",
+    "⭅  leftwards quadruple arrow"
+  ],
+  [
+    "\\RRightarrow",
+    "⭆  rightwards quadruple arrow"
+  ],
+  [
+    "\\bsimilarrightarrow",
+    "⭇  reverse tilde operator above rightwards arrow"
+  ],
+  [
+    "\\rightarrowbackapprox",
+    "⭈  rightwards arrow above reverse almost equal to"
+  ],
+  [
+    "\\similarleftarrow",
+    "⭉  tilde operator above leftwards arrow"
+  ],
+  [
+    "\\leftarrowapprox",
+    "⭊  leftwards arrow above almost equal to"
+  ],
+  [
+    "\\leftarrowbsimilar",
+    "⭋  leftwards arrow above reverse tilde operator"
+  ],
+  [
+    "\\rightarrowbsimilar",
+    "⭌  righttwards arrow above reverse tilde operator"
+  ],
+  [
+    "\\medwhitestar",
+    "⭐  white medium star"
+  ],
+  [
+    "\\medblackstar",
+    "⭑  black medium star"
+  ],
+  [
+    "\\smwhitestar",
+    "⭒  white small star"
+  ],
+  [
+    "\\rightpentagonblack",
+    "⭓  black right-pointing pentagon"
+  ],
+  [
+    "\\rightpentagon",
+    "⭔  white right-pointing pentagon"
+  ],
+  [
+    "\\postalmark",
+    "〒  postal mark"
+  ],
+  [
+    "\\lbrbrak",
+    "〔  left broken bracket"
+  ],
+  [
+    "\\rbrbrak",
+    "〕  right broken bracket"
+  ],
+  [
+    "\\Lbrbrak",
+    "〘  left white tortoise shell bracket"
+  ],
+  [
+    "\\Rbrbrak",
+    "〙  right white tortoise shell bracket"
+  ],
+  [
+    "\\hzigzag",
+    "〰  zigzag"
+  ],
+  [
+    "D",
+    "  variation selector-1"
+  ],
+  [
+    "\\mathbf{A}",
+    "𝐀 mathematical bold capital a"
+  ],
+  [
+    "\\mathbf{B}",
+    "𝐁 mathematical bold capital b"
+  ],
+  [
+    "\\mathbf{C}",
+    "𝐂 mathematical bold capital c"
+  ],
+  [
+    "\\mathbf{D}",
+    "𝐃 mathematical bold capital d"
+  ],
+  [
+    "\\mathbf{E}",
+    "𝐄 mathematical bold capital e"
+  ],
+  [
+    "\\mathbf{F}",
+    "𝐅 mathematical bold capital f"
+  ],
+  [
+    "\\mathbf{G}",
+    "𝐆 mathematical bold capital g"
+  ],
+  [
+    "\\mathbf{H}",
+    "𝐇 mathematical bold capital h"
+  ],
+  [
+    "\\mathbf{I}",
+    "𝐈 mathematical bold capital i"
+  ],
+  [
+    "\\mathbf{J}",
+    "𝐉 mathematical bold capital j"
+  ],
+  [
+    "\\mathbf{K}",
+    "𝐊 mathematical bold capital k"
+  ],
+  [
+    "\\mathbf{L}",
+    "𝐋 mathematical bold capital l"
+  ],
+  [
+    "\\mathbf{M}",
+    "𝐌 mathematical bold capital m"
+  ],
+  [
+    "\\mathbf{N}",
+    "𝐍 mathematical bold capital n"
+  ],
+  [
+    "\\mathbf{O}",
+    "𝐎 mathematical bold capital o"
+  ],
+  [
+    "\\mathbf{P}",
+    "𝐏 mathematical bold capital p"
+  ],
+  [
+    "\\mathbf{Q}",
+    "𝐐 mathematical bold capital q"
+  ],
+  [
+    "\\mathbf{R}",
+    "𝐑 mathematical bold capital r"
+  ],
+  [
+    "\\mathbf{S}",
+    "𝐒 mathematical bold capital s"
+  ],
+  [
+    "\\mathbf{T}",
+    "𝐓 mathematical bold capital t"
+  ],
+  [
+    "\\mathbf{U}",
+    "𝐔 mathematical bold capital u"
+  ],
+  [
+    "\\mathbf{V}",
+    "𝐕 mathematical bold capital v"
+  ],
+  [
+    "\\mathbf{W}",
+    "𝐖 mathematical bold capital w"
+  ],
+  [
+    "\\mathbf{X}",
+    "𝐗 mathematical bold capital x"
+  ],
+  [
+    "\\mathbf{Y}",
+    "𝐘 mathematical bold capital y"
+  ],
+  [
+    "\\mathbf{Z}",
+    "𝐙 mathematical bold capital z"
+  ],
+  [
+    "\\mathbf{a}",
+    "𝐚 mathematical bold small a"
+  ],
+  [
+    "\\mathbf{b}",
+    "𝐛 mathematical bold small b"
+  ],
+  [
+    "\\mathbf{c}",
+    "𝐜 mathematical bold small c"
+  ],
+  [
+    "\\mathbf{d}",
+    "𝐝 mathematical bold small d"
+  ],
+  [
+    "\\mathbf{e}",
+    "𝐞 mathematical bold small e"
+  ],
+  [
+    "\\mathbf{f}",
+    "𝐟 mathematical bold small f"
+  ],
+  [
+    "\\mathbf{g}",
+    "𝐠 mathematical bold small g"
+  ],
+  [
+    "\\mathbf{h}",
+    "𝐡 mathematical bold small h"
+  ],
+  [
+    "\\mathbf{i}",
+    "𝐢 mathematical bold small i"
+  ],
+  [
+    "\\mathbf{j}",
+    "𝐣 mathematical bold small j"
+  ],
+  [
+    "\\mathbf{k}",
+    "𝐤 mathematical bold small k"
+  ],
+  [
+    "\\mathbf{l}",
+    "𝐥 mathematical bold small l"
+  ],
+  [
+    "\\mathbf{m}",
+    "𝐦 mathematical bold small m"
+  ],
+  [
+    "\\mathbf{n}",
+    "𝐧 mathematical bold small n"
+  ],
+  [
+    "\\mathbf{o}",
+    "𝐨 mathematical bold small o"
+  ],
+  [
+    "\\mathbf{p}",
+    "𝐩 mathematical bold small p"
+  ],
+  [
+    "\\mathbf{q}",
+    "𝐪 mathematical bold small q"
+  ],
+  [
+    "\\mathbf{r}",
+    "𝐫 mathematical bold small r"
+  ],
+  [
+    "\\mathbf{s}",
+    "𝐬 mathematical bold small s"
+  ],
+  [
+    "\\mathbf{t}",
+    "𝐭 mathematical bold small t"
+  ],
+  [
+    "\\mathbf{u}",
+    "𝐮 mathematical bold small u"
+  ],
+  [
+    "\\mathbf{v}",
+    "𝐯 mathematical bold small v"
+  ],
+  [
+    "\\mathbf{w}",
+    "𝐰 mathematical bold small w"
+  ],
+  [
+    "\\mathbf{x}",
+    "𝐱 mathematical bold small x"
+  ],
+  [
+    "\\mathbf{y}",
+    "𝐲 mathematical bold small y"
+  ],
+  [
+    "\\mathbf{z}",
+    "𝐳 mathematical bold small z"
+  ],
+  [
+    "A",
+    "𝐴 = \\mathit{a}, mathematical italic capital a"
+  ],
+  [
+    "B",
+    "𝐵 = \\mathit{b}, mathematical italic capital b"
+  ],
+  [
+    "C",
+    "𝐶 = \\mathit{c}, mathematical italic capital c"
+  ],
+  [
+    "D",
+    "𝐷 = \\mathit{d}, mathematical italic capital d"
+  ],
+  [
+    "E",
+    "𝐸 = \\mathit{e}, mathematical italic capital e"
+  ],
+  [
+    "F",
+    "𝐹 = \\mathit{f}, mathematical italic capital f"
+  ],
+  [
+    "G",
+    "𝐺 = \\mathit{g}, mathematical italic capital g"
+  ],
+  [
+    "H",
+    "𝐻 = \\mathit{h}, mathematical italic capital h"
+  ],
+  [
+    "I",
+    "𝐼 = \\mathit{i}, mathematical italic capital i"
+  ],
+  [
+    "J",
+    "𝐽 = \\mathit{j}, mathematical italic capital j"
+  ],
+  [
+    "K",
+    "𝐾 = \\mathit{k}, mathematical italic capital k"
+  ],
+  [
+    "L",
+    "𝐿 = \\mathit{l}, mathematical italic capital l"
+  ],
+  [
+    "M",
+    "𝑀 = \\mathit{m}, mathematical italic capital m"
+  ],
+  [
+    "N",
+    "𝑁 = \\mathit{n}, mathematical italic capital n"
+  ],
+  [
+    "O",
+    "𝑂 = \\mathit{o}, mathematical italic capital o"
+  ],
+  [
+    "P",
+    "𝑃 = \\mathit{p}, mathematical italic capital p"
+  ],
+  [
+    "Q",
+    "𝑄 = \\mathit{q}, mathematical italic capital q"
+  ],
+  [
+    "R",
+    "𝑅 = \\mathit{r}, mathematical italic capital r"
+  ],
+  [
+    "S",
+    "𝑆 = \\mathit{s}, mathematical italic capital s"
+  ],
+  [
+    "T",
+    "𝑇 = \\mathit{t}, mathematical italic capital t"
+  ],
+  [
+    "U",
+    "𝑈 = \\mathit{u}, mathematical italic capital u"
+  ],
+  [
+    "V",
+    "𝑉 = \\mathit{v}, mathematical italic capital v"
+  ],
+  [
+    "W",
+    "𝑊 = \\mathit{w}, mathematical italic capital w"
+  ],
+  [
+    "X",
+    "𝑋 = \\mathit{x}, mathematical italic capital x"
+  ],
+  [
+    "Y",
+    "𝑌 = \\mathit{y}, mathematical italic capital y"
+  ],
+  [
+    "Z",
+    "𝑍 = \\mathit{z}, mathematical italic capital z"
+  ],
+  [
+    "a",
+    "𝑎 = \\mathit{a}, mathematical italic small a"
+  ],
+  [
+    "b",
+    "𝑏 = \\mathit{b}, mathematical italic small b"
+  ],
+  [
+    "c",
+    "𝑐 = \\mathit{c}, mathematical italic small c"
+  ],
+  [
+    "d",
+    "𝑑 = \\mathit{d}, mathematical italic small d"
+  ],
+  [
+    "e",
+    "𝑒 = \\mathit{e}, mathematical italic small e"
+  ],
+  [
+    "f",
+    "𝑓 = \\mathit{f}, mathematical italic small f"
+  ],
+  [
+    "g",
+    "𝑔 = \\mathit{g}, mathematical italic small g"
+  ],
+  [
+    "i",
+    "𝑖 = \\mathit{i}, mathematical italic small i"
+  ],
+  [
+    "j",
+    "𝑗 = \\mathit{j}, mathematical italic small j"
+  ],
+  [
+    "k",
+    "𝑘 = \\mathit{k}, mathematical italic small k"
+  ],
+  [
+    "l",
+    "𝑙 = \\mathit{l}, mathematical italic small l"
+  ],
+  [
+    "m",
+    "𝑚 = \\mathit{m}, mathematical italic small m"
+  ],
+  [
+    "n",
+    "𝑛 = \\mathit{n}, mathematical italic small n"
+  ],
+  [
+    "o",
+    "𝑜 = \\mathit{o}, mathematical italic small o"
+  ],
+  [
+    "p",
+    "𝑝 = \\mathit{p}, mathematical italic small p"
+  ],
+  [
+    "q",
+    "𝑞 = \\mathit{q}, mathematical italic small q"
+  ],
+  [
+    "r",
+    "𝑟 = \\mathit{r}, mathematical italic small r"
+  ],
+  [
+    "s",
+    "𝑠 = \\mathit{s}, mathematical italic small s"
+  ],
+  [
+    "t",
+    "𝑡 = \\mathit{t}, mathematical italic small t"
+  ],
+  [
+    "u",
+    "𝑢 = \\mathit{u}, mathematical italic small u"
+  ],
+  [
+    "v",
+    "𝑣 = \\mathit{v}, mathematical italic small v"
+  ],
+  [
+    "w",
+    "𝑤 = \\mathit{w}, mathematical italic small w"
+  ],
+  [
+    "x",
+    "𝑥 = \\mathit{x}, mathematical italic small x"
+  ],
+  [
+    "y",
+    "𝑦 = \\mathit{y}, mathematical italic small y"
+  ],
+  [
+    "z",
+    "𝑧 = \\mathit{z}, mathematical italic small z"
+  ],
+  [
+    "\\mathbfit{A}",
+    "𝑨 = \\mathbold{a} (fixmath), mathematical bold italic capital a"
+  ],
+  [
+    "\\mathbfit{B}",
+    "𝑩 = \\mathbold{b} (fixmath), mathematical bold italic capital b"
+  ],
+  [
+    "\\mathbfit{C}",
+    "𝑪 = \\mathbold{c} (fixmath), mathematical bold italic capital c"
+  ],
+  [
+    "\\mathbfit{D}",
+    "𝑫 = \\mathbold{d} (fixmath), mathematical bold italic capital d"
+  ],
+  [
+    "\\mathbfit{E}",
+    "𝑬 = \\mathbold{e} (fixmath), mathematical bold italic capital e"
+  ],
+  [
+    "\\mathbfit{F}",
+    "𝑭 = \\mathbold{f} (fixmath), mathematical bold italic capital f"
+  ],
+  [
+    "\\mathbfit{G}",
+    "𝑮 = \\mathbold{g} (fixmath), mathematical bold italic capital g"
+  ],
+  [
+    "\\mathbfit{H}",
+    "𝑯 = \\mathbold{h} (fixmath), mathematical bold italic capital h"
+  ],
+  [
+    "\\mathbfit{I}",
+    "𝑰 = \\mathbold{i} (fixmath), mathematical bold italic capital i"
+  ],
+  [
+    "\\mathbfit{J}",
+    "𝑱 = \\mathbold{j} (fixmath), mathematical bold italic capital j"
+  ],
+  [
+    "\\mathbfit{K}",
+    "𝑲 = \\mathbold{k} (fixmath), mathematical bold italic capital k"
+  ],
+  [
+    "\\mathbfit{L}",
+    "𝑳 = \\mathbold{l} (fixmath), mathematical bold italic capital l"
+  ],
+  [
+    "\\mathbfit{M}",
+    "𝑴 = \\mathbold{m} (fixmath), mathematical bold italic capital m"
+  ],
+  [
+    "\\mathbfit{N}",
+    "𝑵 = \\mathbold{n} (fixmath), mathematical bold italic capital n"
+  ],
+  [
+    "\\mathbfit{O}",
+    "𝑶 = \\mathbold{o} (fixmath), mathematical bold italic capital o"
+  ],
+  [
+    "\\mathbfit{P}",
+    "𝑷 = \\mathbold{p} (fixmath), mathematical bold italic capital p"
+  ],
+  [
+    "\\mathbfit{Q}",
+    "𝑸 = \\mathbold{q} (fixmath), mathematical bold italic capital q"
+  ],
+  [
+    "\\mathbfit{R}",
+    "𝑹 = \\mathbold{r} (fixmath), mathematical bold italic capital r"
+  ],
+  [
+    "\\mathbfit{S}",
+    "𝑺 = \\mathbold{s} (fixmath), mathematical bold italic capital s"
+  ],
+  [
+    "\\mathbfit{T}",
+    "𝑻 = \\mathbold{t} (fixmath), mathematical bold italic capital t"
+  ],
+  [
+    "\\mathbfit{U}",
+    "𝑼 = \\mathbold{u} (fixmath), mathematical bold italic capital u"
+  ],
+  [
+    "\\mathbfit{V}",
+    "𝑽 = \\mathbold{v} (fixmath), mathematical bold italic capital v"
+  ],
+  [
+    "\\mathbfit{W}",
+    "𝑾 = \\mathbold{w} (fixmath), mathematical bold italic capital w"
+  ],
+  [
+    "\\mathbfit{X}",
+    "𝑿 = \\mathbold{x} (fixmath), mathematical bold italic capital x"
+  ],
+  [
+    "\\mathbfit{Y}",
+    "𝒀 = \\mathbold{y} (fixmath), mathematical bold italic capital y"
+  ],
+  [
+    "\\mathbfit{Z}",
+    "𝒁 = \\mathbold{z} (fixmath), mathematical bold italic capital z"
+  ],
+  [
+    "\\mathbfit{a}",
+    "𝒂 = \\mathbold{a} (fixmath), mathematical bold italic small a"
+  ],
+  [
+    "\\mathbfit{b}",
+    "𝒃 = \\mathbold{b} (fixmath), mathematical bold italic small b"
+  ],
+  [
+    "\\mathbfit{c}",
+    "𝒄 = \\mathbold{c} (fixmath), mathematical bold italic small c"
+  ],
+  [
+    "\\mathbfit{d}",
+    "𝒅 = \\mathbold{d} (fixmath), mathematical bold italic small d"
+  ],
+  [
+    "\\mathbfit{e}",
+    "𝒆 = \\mathbold{e} (fixmath), mathematical bold italic small e"
+  ],
+  [
+    "\\mathbfit{f}",
+    "𝒇 = \\mathbold{f} (fixmath), mathematical bold italic small f"
+  ],
+  [
+    "\\mathbfit{g}",
+    "𝒈 = \\mathbold{g} (fixmath), mathematical bold italic small g"
+  ],
+  [
+    "\\mathbfit{h}",
+    "𝒉 = \\mathbold{h} (fixmath), mathematical bold italic small h"
+  ],
+  [
+    "\\mathbfit{i}",
+    "𝒊 = \\mathbold{i} (fixmath), mathematical bold italic small i"
+  ],
+  [
+    "\\mathbfit{j}",
+    "𝒋 = \\mathbold{j} (fixmath), mathematical bold italic small j"
+  ],
+  [
+    "\\mathbfit{k}",
+    "𝒌 = \\mathbold{k} (fixmath), mathematical bold italic small k"
+  ],
+  [
+    "\\mathbfit{l}",
+    "𝒍 = \\mathbold{l} (fixmath), mathematical bold italic small l"
+  ],
+  [
+    "\\mathbfit{m}",
+    "𝒎 = \\mathbold{m} (fixmath), mathematical bold italic small m"
+  ],
+  [
+    "\\mathbfit{n}",
+    "𝒏 = \\mathbold{n} (fixmath), mathematical bold italic small n"
+  ],
+  [
+    "\\mathbfit{o}",
+    "𝒐 = \\mathbold{o} (fixmath), mathematical bold italic small o"
+  ],
+  [
+    "\\mathbfit{p}",
+    "𝒑 = \\mathbold{p} (fixmath), mathematical bold italic small p"
+  ],
+  [
+    "\\mathbfit{q}",
+    "𝒒 = \\mathbold{q} (fixmath), mathematical bold italic small q"
+  ],
+  [
+    "\\mathbfit{r}",
+    "𝒓 = \\mathbold{r} (fixmath), mathematical bold italic small r"
+  ],
+  [
+    "\\mathbfit{s}",
+    "𝒔 = \\mathbold{s} (fixmath), mathematical bold italic small s"
+  ],
+  [
+    "\\mathbfit{t}",
+    "𝒕 = \\mathbold{t} (fixmath), mathematical bold italic small t"
+  ],
+  [
+    "\\mathbfit{u}",
+    "𝒖 = \\mathbold{u} (fixmath), mathematical bold italic small u"
+  ],
+  [
+    "\\mathbfit{v}",
+    "𝒗 = \\mathbold{v} (fixmath), mathematical bold italic small v"
+  ],
+  [
+    "\\mathbfit{w}",
+    "𝒘 = \\mathbold{w} (fixmath), mathematical bold italic small w"
+  ],
+  [
+    "\\mathbfit{x}",
+    "𝒙 = \\mathbold{x} (fixmath), mathematical bold italic small x"
+  ],
+  [
+    "\\mathbfit{y}",
+    "𝒚 = \\mathbold{y} (fixmath), mathematical bold italic small y"
+  ],
+  [
+    "\\mathbfit{z}",
+    "𝒛 = \\mathbold{z} (fixmath), mathematical bold italic small z"
+  ],
+  [
+    "\\mathcal{A}",
+    "𝒜 mathematical script capital a"
+  ],
+  [
+    "\\mathcal{C}",
+    "𝒞 mathematical script capital c"
+  ],
+  [
+    "\\mathcal{D}",
+    "𝒟 mathematical script capital d"
+  ],
+  [
+    "\\mathcal{G}",
+    "𝒢 mathematical script capital g"
+  ],
+  [
+    "\\mathcal{J}",
+    "𝒥 mathematical script capital j"
+  ],
+  [
+    "\\mathcal{K}",
+    "𝒦 mathematical script capital k"
+  ],
+  [
+    "\\mathcal{N}",
+    "𝒩 mathematical script capital n"
+  ],
+  [
+    "\\mathcal{O}",
+    "𝒪 mathematical script capital o"
+  ],
+  [
+    "\\mathcal{P}",
+    "𝒫 mathematical script capital p"
+  ],
+  [
+    "\\mathcal{Q}",
+    "𝒬 mathematical script capital q"
+  ],
+  [
+    "\\mathcal{S}",
+    "𝒮 mathematical script capital s"
+  ],
+  [
+    "\\mathcal{T}",
+    "𝒯 mathematical script capital t"
+  ],
+  [
+    "\\mathcal{U}",
+    "𝒰 mathematical script capital u"
+  ],
+  [
+    "\\mathcal{V}",
+    "𝒱 mathematical script capital v"
+  ],
+  [
+    "\\mathcal{W}",
+    "𝒲 mathematical script capital w"
+  ],
+  [
+    "\\mathcal{X}",
+    "𝒳 mathematical script capital x"
+  ],
+  [
+    "\\mathcal{Y}",
+    "𝒴 mathematical script capital y"
+  ],
+  [
+    "\\mathcal{Z}",
+    "𝒵 mathematical script capital z"
+  ],
+  [
+    "\\mathcal{a}",
+    "𝒶 mathematical script small a"
+  ],
+  [
+    "\\mathcal{b}",
+    "𝒷 mathematical script small b"
+  ],
+  [
+    "\\mathcal{c}",
+    "𝒸 mathematical script small c"
+  ],
+  [
+    "\\mathcal{d}",
+    "𝒹 mathematical script small d"
+  ],
+  [
+    "\\mathcal{f}",
+    "𝒻 mathematical script small f"
+  ],
+  [
+    "\\mathcal{h}",
+    "𝒽 mathematical script small h"
+  ],
+  [
+    "\\mathcal{i}",
+    "𝒾 mathematical script small i"
+  ],
+  [
+    "\\mathcal{j}",
+    "𝒿 mathematical script small j"
+  ],
+  [
+    "\\mathcal{k}",
+    "𝓀 mathematical script small k"
+  ],
+  [
+    "\\mathcal{l}",
+    "𝓁 mathematical script small l"
+  ],
+  [
+    "\\mathcal{m}",
+    "𝓂 mathematical script small m"
+  ],
+  [
+    "\\mathcal{n}",
+    "𝓃 mathematical script small n"
+  ],
+  [
+    "\\mathcal{p}",
+    "𝓅 mathematical script small p"
+  ],
+  [
+    "\\mathcal{q}",
+    "𝓆 mathematical script small q"
+  ],
+  [
+    "\\mathcal{r}",
+    "𝓇 mathematical script small r"
+  ],
+  [
+    "\\mathcal{s}",
+    "𝓈 mathematical script small s"
+  ],
+  [
+    "\\mathcal{t}",
+    "𝓉 mathematical script small t"
+  ],
+  [
+    "\\mathcal{u}",
+    "𝓊 mathematical script small u"
+  ],
+  [
+    "\\mathcal{v}",
+    "𝓋 mathematical script small v"
+  ],
+  [
+    "\\mathcal{w}",
+    "𝓌 mathematical script small w"
+  ],
+  [
+    "\\mathcal{x}",
+    "𝓍 mathematical script small x"
+  ],
+  [
+    "\\mathcal{y}",
+    "𝓎 mathematical script small y"
+  ],
+  [
+    "\\mathcal{z}",
+    "𝓏 mathematical script small z"
+  ],
+  [
+    "\\mbfscrA",
+    "𝓐  mathematical bold script capital a"
+  ],
+  [
+    "\\mbfscrB",
+    "𝓑  mathematical bold script capital b"
+  ],
+  [
+    "\\mbfscrC",
+    "𝓒  mathematical bold script capital c"
+  ],
+  [
+    "\\mbfscrD",
+    "𝓓  mathematical bold script capital d"
+  ],
+  [
+    "\\mbfscrE",
+    "𝓔  mathematical bold script capital e"
+  ],
+  [
+    "\\mbfscrF",
+    "𝓕  mathematical bold script capital f"
+  ],
+  [
+    "\\mbfscrG",
+    "𝓖  mathematical bold script capital g"
+  ],
+  [
+    "\\mbfscrH",
+    "𝓗  mathematical bold script capital h"
+  ],
+  [
+    "\\mbfscrI",
+    "𝓘  mathematical bold script capital i"
+  ],
+  [
+    "\\mbfscrJ",
+    "𝓙  mathematical bold script capital j"
+  ],
+  [
+    "\\mbfscrK",
+    "𝓚  mathematical bold script capital k"
+  ],
+  [
+    "\\mbfscrL",
+    "𝓛  mathematical bold script capital l"
+  ],
+  [
+    "\\mbfscrM",
+    "𝓜  mathematical bold script capital m"
+  ],
+  [
+    "\\mbfscrN",
+    "𝓝  mathematical bold script capital n"
+  ],
+  [
+    "\\mbfscrO",
+    "𝓞  mathematical bold script capital o"
+  ],
+  [
+    "\\mbfscrP",
+    "𝓟  mathematical bold script capital p"
+  ],
+  [
+    "\\mbfscrQ",
+    "𝓠  mathematical bold script capital q"
+  ],
+  [
+    "\\mbfscrR",
+    "𝓡  mathematical bold script capital r"
+  ],
+  [
+    "\\mbfscrS",
+    "𝓢  mathematical bold script capital s"
+  ],
+  [
+    "\\mbfscrT",
+    "𝓣  mathematical bold script capital t"
+  ],
+  [
+    "\\mbfscrU",
+    "𝓤  mathematical bold script capital u"
+  ],
+  [
+    "\\mbfscrV",
+    "𝓥  mathematical bold script capital v"
+  ],
+  [
+    "\\mbfscrW",
+    "𝓦  mathematical bold script capital w"
+  ],
+  [
+    "\\mbfscrX",
+    "𝓧  mathematical bold script capital x"
+  ],
+  [
+    "\\mbfscrY",
+    "𝓨  mathematical bold script capital y"
+  ],
+  [
+    "\\mbfscrZ",
+    "𝓩  mathematical bold script capital z"
+  ],
+  [
+    "\\mbfscra",
+    "𝓪  mathematical bold script small a"
+  ],
+  [
+    "\\mbfscrb",
+    "𝓫  mathematical bold script small b"
+  ],
+  [
+    "\\mbfscrc",
+    "𝓬  mathematical bold script small c"
+  ],
+  [
+    "\\mbfscrd",
+    "𝓭  mathematical bold script small d"
+  ],
+  [
+    "\\mbfscre",
+    "𝓮  mathematical bold script small e"
+  ],
+  [
+    "\\mbfscrf",
+    "𝓯  mathematical bold script small f"
+  ],
+  [
+    "\\mbfscrg",
+    "𝓰  mathematical bold script small g"
+  ],
+  [
+    "\\mbfscrh",
+    "𝓱  mathematical bold script small h"
+  ],
+  [
+    "\\mbfscri",
+    "𝓲  mathematical bold script small i"
+  ],
+  [
+    "\\mbfscrj",
+    "𝓳  mathematical bold script small j"
+  ],
+  [
+    "\\mbfscrk",
+    "𝓴  mathematical bold script small k"
+  ],
+  [
+    "\\mbfscrl",
+    "𝓵  mathematical bold script small l"
+  ],
+  [
+    "\\mbfscrm",
+    "𝓶  mathematical bold script small m"
+  ],
+  [
+    "\\mbfscrn",
+    "𝓷  mathematical bold script small n"
+  ],
+  [
+    "\\mbfscro",
+    "𝓸  mathematical bold script small o"
+  ],
+  [
+    "\\mbfscrp",
+    "𝓹  mathematical bold script small p"
+  ],
+  [
+    "\\mbfscrq",
+    "𝓺  mathematical bold script small q"
+  ],
+  [
+    "\\mbfscrr",
+    "𝓻  mathematical bold script small r"
+  ],
+  [
+    "\\mbfscrs",
+    "𝓼  mathematical bold script small s"
+  ],
+  [
+    "\\mbfscrt",
+    "𝓽  mathematical bold script small t"
+  ],
+  [
+    "\\mbfscru",
+    "𝓾  mathematical bold script small u"
+  ],
+  [
+    "\\mbfscrv",
+    "𝓿  mathematical bold script small v"
+  ],
+  [
+    "\\mbfscrw",
+    "𝔀  mathematical bold script small w"
+  ],
+  [
+    "\\mbfscrx",
+    "𝔁  mathematical bold script small x"
+  ],
+  [
+    "\\mbfscry",
+    "𝔂  mathematical bold script small y"
+  ],
+  [
+    "\\mbfscrz",
+    "𝔃  mathematical bold script small z"
+  ],
+  [
+    "\\mathfrak{A}",
+    "𝔄 mathematical fraktur capital a"
+  ],
+  [
+    "\\mathfrak{B}",
+    "𝔅 mathematical fraktur capital b"
+  ],
+  [
+    "\\mathfrak{D}",
+    "𝔇 mathematical fraktur capital d"
+  ],
+  [
+    "\\mathfrak{E}",
+    "𝔈 mathematical fraktur capital e"
+  ],
+  [
+    "\\mathfrak{F}",
+    "𝔉 mathematical fraktur capital f"
+  ],
+  [
+    "\\mathfrak{G}",
+    "𝔊 mathematical fraktur capital g"
+  ],
+  [
+    "\\mathfrak{J}",
+    "𝔍 mathematical fraktur capital j"
+  ],
+  [
+    "\\mathfrak{K}",
+    "𝔎 mathematical fraktur capital k"
+  ],
+  [
+    "\\mathfrak{L}",
+    "𝔏 mathematical fraktur capital l"
+  ],
+  [
+    "\\mathfrak{M}",
+    "𝔐 mathematical fraktur capital m"
+  ],
+  [
+    "\\mathfrak{N}",
+    "𝔑 mathematical fraktur capital n"
+  ],
+  [
+    "\\mathfrak{O}",
+    "𝔒 mathematical fraktur capital o"
+  ],
+  [
+    "\\mathfrak{P}",
+    "𝔓 mathematical fraktur capital p"
+  ],
+  [
+    "\\mathfrak{Q}",
+    "𝔔 mathematical fraktur capital q"
+  ],
+  [
+    "\\mathfrak{S}",
+    "𝔖 mathematical fraktur capital s"
+  ],
+  [
+    "\\mathfrak{T}",
+    "𝔗 mathematical fraktur capital t"
+  ],
+  [
+    "\\mathfrak{U}",
+    "𝔘 mathematical fraktur capital u"
+  ],
+  [
+    "\\mathfrak{V}",
+    "𝔙 mathematical fraktur capital v"
+  ],
+  [
+    "\\mathfrak{W}",
+    "𝔚 mathematical fraktur capital w"
+  ],
+  [
+    "\\mathfrak{X}",
+    "𝔛 mathematical fraktur capital x"
+  ],
+  [
+    "\\mathfrak{Y}",
+    "𝔜 mathematical fraktur capital y"
+  ],
+  [
+    "\\mathfrak{a}",
+    "𝔞 mathematical fraktur small a"
+  ],
+  [
+    "\\mathfrak{b}",
+    "𝔟 mathematical fraktur small b"
+  ],
+  [
+    "\\mathfrak{c}",
+    "𝔠 mathematical fraktur small c"
+  ],
+  [
+    "\\mathfrak{d}",
+    "𝔡 mathematical fraktur small d"
+  ],
+  [
+    "\\mathfrak{e}",
+    "𝔢 mathematical fraktur small e"
+  ],
+  [
+    "\\mathfrak{f}",
+    "𝔣 mathematical fraktur small f"
+  ],
+  [
+    "\\mathfrak{g}",
+    "𝔤 mathematical fraktur small g"
+  ],
+  [
+    "\\mathfrak{h}",
+    "𝔥 mathematical fraktur small h"
+  ],
+  [
+    "\\mathfrak{i}",
+    "𝔦 mathematical fraktur small i"
+  ],
+  [
+    "\\mathfrak{j}",
+    "𝔧 mathematical fraktur small j"
+  ],
+  [
+    "\\mathfrak{k}",
+    "𝔨 mathematical fraktur small k"
+  ],
+  [
+    "\\mathfrak{l}",
+    "𝔩 mathematical fraktur small l"
+  ],
+  [
+    "\\mathfrak{m}",
+    "𝔪 mathematical fraktur small m"
+  ],
+  [
+    "\\mathfrak{n}",
+    "𝔫 mathematical fraktur small n"
+  ],
+  [
+    "\\mathfrak{o}",
+    "𝔬 mathematical fraktur small o"
+  ],
+  [
+    "\\mathfrak{p}",
+    "𝔭 mathematical fraktur small p"
+  ],
+  [
+    "\\mathfrak{q}",
+    "𝔮 mathematical fraktur small q"
+  ],
+  [
+    "\\mathfrak{r}",
+    "𝔯 mathematical fraktur small r"
+  ],
+  [
+    "\\mathfrak{s}",
+    "𝔰 mathematical fraktur small s"
+  ],
+  [
+    "\\mathfrak{t}",
+    "𝔱 mathematical fraktur small t"
+  ],
+  [
+    "\\mathfrak{u}",
+    "𝔲 mathematical fraktur small u"
+  ],
+  [
+    "\\mathfrak{v}",
+    "𝔳 mathematical fraktur small v"
+  ],
+  [
+    "\\mathfrak{w}",
+    "𝔴 mathematical fraktur small w"
+  ],
+  [
+    "\\mathfrak{x}",
+    "𝔵 mathematical fraktur small x"
+  ],
+  [
+    "\\mathfrak{y}",
+    "𝔶 mathematical fraktur small y"
+  ],
+  [
+    "\\mathfrak{z}",
+    "𝔷 mathematical fraktur small z"
+  ],
+  [
+    "\\mathbb{A}",
+    "𝔸 = \\mathds{a} (dsfont), mathematical double-struck capital a"
+  ],
+  [
+    "\\mathbb{B}",
+    "𝔹 = \\mathds{b} (dsfont), matmathematical double-struck capital b"
+  ],
+  [
+    "\\mathbb{D}",
+    "𝔻 = \\mathds{d} (dsfont), matmathematical double-struck capital d"
+  ],
+  [
+    "\\mathbb{E}",
+    "𝔼 = \\mathds{e} (dsfont), matmathematical double-struck capital e"
+  ],
+  [
+    "\\mathbb{F}",
+    "𝔽 = \\mathds{f} (dsfont), matmathematical double-struck capital f"
+  ],
+  [
+    "\\mathbb{G}",
+    "𝔾 = \\mathds{g} (dsfont), matmathematical double-struck capital g"
+  ],
+  [
+    "\\mathbb{I}",
+    "𝕀 = \\mathds{i} (dsfont), matmathematical double-struck capital i"
+  ],
+  [
+    "\\mathbb{J}",
+    "𝕁 = \\mathds{j} (dsfont), matmathematical double-struck capital j"
+  ],
+  [
+    "\\mathbb{K}",
+    "𝕂 = \\mathds{k} (dsfont), matmathematical double-struck capital k"
+  ],
+  [
+    "\\mathbb{L}",
+    "𝕃 = \\mathds{l} (dsfont), matmathematical double-struck capital l"
+  ],
+  [
+    "\\mathbb{M}",
+    "𝕄 = \\mathds{m} (dsfont), matmathematical double-struck capital m"
+  ],
+  [
+    "\\mathbb{O}",
+    "𝕆 = \\mathds{o} (dsfont), matmathematical double-struck capital o"
+  ],
+  [
+    "\\mathbb{S}",
+    "𝕊 = \\mathds{s} (dsfont), matmathematical double-struck capital s"
+  ],
+  [
+    "\\mathbb{T}",
+    "𝕋 = \\mathds{t} (dsfont), matmathematical double-struck capital t"
+  ],
+  [
+    "\\mathbb{U}",
+    "𝕌 = \\mathds{u} (dsfont), matmathematical double-struck capital u"
+  ],
+  [
+    "\\mathbb{V}",
+    "𝕍 = \\mathds{v} (dsfont), matmathematical double-struck capital v"
+  ],
+  [
+    "\\mathbb{W}",
+    "𝕎 = \\mathds{w} (dsfont), matmathematical double-struck capital w"
+  ],
+  [
+    "\\mathbb{X}",
+    "𝕏 = \\mathds{x} (dsfont), matmathematical double-struck capital x"
+  ],
+  [
+    "\\mathbb{Y}",
+    "𝕐 = \\mathds{y} (dsfont), matmathematical double-struck capital y"
+  ],
+  [
+    "\\mathbb{a}",
+    "𝕒 mathematical double-struck small a"
+  ],
+  [
+    "\\mathbb{b}",
+    "𝕓 mathematical double-struck small b"
+  ],
+  [
+    "\\mathbb{c}",
+    "𝕔 mathematical double-struck small c"
+  ],
+  [
+    "\\mathbb{d}",
+    "𝕕 mathematical double-struck small d"
+  ],
+  [
+    "\\mathbb{e}",
+    "𝕖 mathematical double-struck small e"
+  ],
+  [
+    "\\mathbb{f}",
+    "𝕗 mathematical double-struck small f"
+  ],
+  [
+    "\\mathbb{g}",
+    "𝕘 mathematical double-struck small g"
+  ],
+  [
+    "\\mathbb{h}",
+    "𝕙 mathematical double-struck small h"
+  ],
+  [
+    "\\mathbb{i}",
+    "𝕚 mathematical double-struck small i"
+  ],
+  [
+    "\\mathbb{j}",
+    "𝕛 mathematical double-struck small j"
+  ],
+  [
+    "\\mathbb{k}",
+    "𝕜 = \\bbbk (amssymb), mathematical double-struck small k"
+  ],
+  [
+    "\\mathbb{l}",
+    "𝕝 mathematical double-struck small l"
+  ],
+  [
+    "\\mathbb{m}",
+    "𝕞 mathematical double-struck small m"
+  ],
+  [
+    "\\mathbb{n}",
+    "𝕟 mathematical double-struck small n"
+  ],
+  [
+    "\\mathbb{o}",
+    "𝕠 mathematical double-struck small o"
+  ],
+  [
+    "\\mathbb{p}",
+    "𝕡 mathematical double-struck small p"
+  ],
+  [
+    "\\mathbb{q}",
+    "𝕢 mathematical double-struck small q"
+  ],
+  [
+    "\\mathbb{r}",
+    "𝕣 mathematical double-struck small r"
+  ],
+  [
+    "\\mathbb{s}",
+    "𝕤 mathematical double-struck small s"
+  ],
+  [
+    "\\mathbb{t}",
+    "𝕥 mathematical double-struck small t"
+  ],
+  [
+    "\\mathbb{u}",
+    "𝕦 mathematical double-struck small u"
+  ],
+  [
+    "\\mathbb{v}",
+    "𝕧 mathematical double-struck small v"
+  ],
+  [
+    "\\mathbb{w}",
+    "𝕨 mathematical double-struck small w"
+  ],
+  [
+    "\\mathbb{x}",
+    "𝕩 mathematical double-struck small x"
+  ],
+  [
+    "\\mathbb{y}",
+    "𝕪 mathematical double-struck small y"
+  ],
+  [
+    "\\mathbb{z}",
+    "𝕫 mathematical double-struck small z"
+  ],
+  [
+    "\\mathsf{A}",
+    "𝖠 mathematical sans-serif capital a"
+  ],
+  [
+    "\\mathsf{B}",
+    "𝖡 mathematical sans-serif capital b"
+  ],
+  [
+    "\\mathsf{C}",
+    "𝖢 mathematical sans-serif capital c"
+  ],
+  [
+    "\\mathsf{D}",
+    "𝖣 mathematical sans-serif capital d"
+  ],
+  [
+    "\\mathsf{E}",
+    "𝖤 mathematical sans-serif capital e"
+  ],
+  [
+    "\\mathsf{F}",
+    "𝖥 mathematical sans-serif capital f"
+  ],
+  [
+    "\\mathsf{G}",
+    "𝖦 mathematical sans-serif capital g"
+  ],
+  [
+    "\\mathsf{H}",
+    "𝖧 mathematical sans-serif capital h"
+  ],
+  [
+    "\\mathsf{I}",
+    "𝖨 mathematical sans-serif capital i"
+  ],
+  [
+    "\\mathsf{J}",
+    "𝖩 mathematical sans-serif capital j"
+  ],
+  [
+    "\\mathsf{K}",
+    "𝖪 mathematical sans-serif capital k"
+  ],
+  [
+    "\\mathsf{L}",
+    "𝖫 mathematical sans-serif capital l"
+  ],
+  [
+    "\\mathsf{M}",
+    "𝖬 mathematical sans-serif capital m"
+  ],
+  [
+    "\\mathsf{N}",
+    "𝖭 mathematical sans-serif capital n"
+  ],
+  [
+    "\\mathsf{O}",
+    "𝖮 mathematical sans-serif capital o"
+  ],
+  [
+    "\\mathsf{P}",
+    "𝖯 mathematical sans-serif capital p"
+  ],
+  [
+    "\\mathsf{Q}",
+    "𝖰 mathematical sans-serif capital q"
+  ],
+  [
+    "\\mathsf{R}",
+    "𝖱 mathematical sans-serif capital r"
+  ],
+  [
+    "\\mathsf{S}",
+    "𝖲 mathematical sans-serif capital s"
+  ],
+  [
+    "\\mathsf{T}",
+    "𝖳 mathematical sans-serif capital t"
+  ],
+  [
+    "\\mathsf{U}",
+    "𝖴 mathematical sans-serif capital u"
+  ],
+  [
+    "\\mathsf{V}",
+    "𝖵 mathematical sans-serif capital v"
+  ],
+  [
+    "\\mathsf{W}",
+    "𝖶 mathematical sans-serif capital w"
+  ],
+  [
+    "\\mathsf{X}",
+    "𝖷 mathematical sans-serif capital x"
+  ],
+  [
+    "\\mathsf{Y}",
+    "𝖸 mathematical sans-serif capital y"
+  ],
+  [
+    "\\mathsf{Z}",
+    "𝖹 mathematical sans-serif capital z"
+  ],
+  [
+    "\\mathsf{a}",
+    "𝖺 mathematical sans-serif small a"
+  ],
+  [
+    "\\mathsf{b}",
+    "𝖻 mathematical sans-serif small b"
+  ],
+  [
+    "\\mathsf{c}",
+    "𝖼 mathematical sans-serif small c"
+  ],
+  [
+    "\\mathsf{d}",
+    "𝖽 mathematical sans-serif small d"
+  ],
+  [
+    "\\mathsf{e}",
+    "𝖾 mathematical sans-serif small e"
+  ],
+  [
+    "\\mathsf{f}",
+    "𝖿 mathematical sans-serif small f"
+  ],
+  [
+    "\\mathsf{g}",
+    "𝗀 mathematical sans-serif small g"
+  ],
+  [
+    "\\mathsf{h}",
+    "𝗁 mathematical sans-serif small h"
+  ],
+  [
+    "\\mathsf{i}",
+    "𝗂 mathematical sans-serif small i"
+  ],
+  [
+    "\\mathsf{j}",
+    "𝗃 mathematical sans-serif small j"
+  ],
+  [
+    "\\mathsf{k}",
+    "𝗄 mathematical sans-serif small k"
+  ],
+  [
+    "\\mathsf{l}",
+    "𝗅 mathematical sans-serif small l"
+  ],
+  [
+    "\\mathsf{m}",
+    "𝗆 mathematical sans-serif small m"
+  ],
+  [
+    "\\mathsf{n}",
+    "𝗇 mathematical sans-serif small n"
+  ],
+  [
+    "\\mathsf{o}",
+    "𝗈 mathematical sans-serif small o"
+  ],
+  [
+    "\\mathsf{p}",
+    "𝗉 mathematical sans-serif small p"
+  ],
+  [
+    "\\mathsf{q}",
+    "𝗊 mathematical sans-serif small q"
+  ],
+  [
+    "\\mathsf{r}",
+    "𝗋 mathematical sans-serif small r"
+  ],
+  [
+    "\\mathsf{s}",
+    "𝗌 mathematical sans-serif small s"
+  ],
+  [
+    "\\mathsf{t}",
+    "𝗍 mathematical sans-serif small t"
+  ],
+  [
+    "\\mathsf{u}",
+    "𝗎 mathematical sans-serif small u"
+  ],
+  [
+    "\\mathsf{v}",
+    "𝗏 mathematical sans-serif small v"
+  ],
+  [
+    "\\mathsf{w}",
+    "𝗐 mathematical sans-serif small w"
+  ],
+  [
+    "\\mathsf{x}",
+    "𝗑 mathematical sans-serif small x"
+  ],
+  [
+    "\\mathsf{y}",
+    "𝗒 mathematical sans-serif small y"
+  ],
+  [
+    "\\mathsf{z}",
+    "𝗓 mathematical sans-serif small z"
+  ],
+  [
+    "\\mathsfbf{A}",
+    "𝗔 mathematical sans-serif bold capital a"
+  ],
+  [
+    "\\mathsfbf{B}",
+    "𝗕 mathematical sans-serif bold capital b"
+  ],
+  [
+    "\\mathsfbf{C}",
+    "𝗖 mathematical sans-serif bold capital c"
+  ],
+  [
+    "\\mathsfbf{D}",
+    "𝗗 mathematical sans-serif bold capital d"
+  ],
+  [
+    "\\mathsfbf{E}",
+    "𝗘 mathematical sans-serif bold capital e"
+  ],
+  [
+    "\\mathsfbf{F}",
+    "𝗙 mathematical sans-serif bold capital f"
+  ],
+  [
+    "\\mathsfbf{G}",
+    "𝗚 mathematical sans-serif bold capital g"
+  ],
+  [
+    "\\mathsfbf{H}",
+    "𝗛 mathematical sans-serif bold capital h"
+  ],
+  [
+    "\\mathsfbf{I}",
+    "𝗜 mathematical sans-serif bold capital i"
+  ],
+  [
+    "\\mathsfbf{J}",
+    "𝗝 mathematical sans-serif bold capital j"
+  ],
+  [
+    "\\mathsfbf{K}",
+    "𝗞 mathematical sans-serif bold capital k"
+  ],
+  [
+    "\\mathsfbf{L}",
+    "𝗟 mathematical sans-serif bold capital l"
+  ],
+  [
+    "\\mathsfbf{M}",
+    "𝗠 mathematical sans-serif bold capital m"
+  ],
+  [
+    "\\mathsfbf{N}",
+    "𝗡 mathematical sans-serif bold capital n"
+  ],
+  [
+    "\\mathsfbf{O}",
+    "𝗢 mathematical sans-serif bold capital o"
+  ],
+  [
+    "\\mathsfbf{P}",
+    "𝗣 mathematical sans-serif bold capital p"
+  ],
+  [
+    "\\mathsfbf{Q}",
+    "𝗤 mathematical sans-serif bold capital q"
+  ],
+  [
+    "\\mathsfbf{R}",
+    "𝗥 mathematical sans-serif bold capital r"
+  ],
+  [
+    "\\mathsfbf{S}",
+    "𝗦 mathematical sans-serif bold capital s"
+  ],
+  [
+    "\\mathsfbf{T}",
+    "𝗧 mathematical sans-serif bold capital t"
+  ],
+  [
+    "\\mathsfbf{U}",
+    "𝗨 mathematical sans-serif bold capital u"
+  ],
+  [
+    "\\mathsfbf{V}",
+    "𝗩 mathematical sans-serif bold capital v"
+  ],
+  [
+    "\\mathsfbf{W}",
+    "𝗪 mathematical sans-serif bold capital w"
+  ],
+  [
+    "\\mathsfbf{X}",
+    "𝗫 mathematical sans-serif bold capital x"
+  ],
+  [
+    "\\mathsfbf{Y}",
+    "𝗬 mathematical sans-serif bold capital y"
+  ],
+  [
+    "\\mathsfbf{Z}",
+    "𝗭 mathematical sans-serif bold capital z"
+  ],
+  [
+    "\\mathsfbf{a}",
+    "𝗮 mathematical sans-serif bold small a"
+  ],
+  [
+    "\\mathsfbf{b}",
+    "𝗯 mathematical sans-serif bold small b"
+  ],
+  [
+    "\\mathsfbf{c}",
+    "𝗰 mathematical sans-serif bold small c"
+  ],
+  [
+    "\\mathsfbf{d}",
+    "𝗱 mathematical sans-serif bold small d"
+  ],
+  [
+    "\\mathsfbf{e}",
+    "𝗲 mathematical sans-serif bold small e"
+  ],
+  [
+    "\\mathsfbf{f}",
+    "𝗳 mathematical sans-serif bold small f"
+  ],
+  [
+    "\\mathsfbf{g}",
+    "𝗴 mathematical sans-serif bold small g"
+  ],
+  [
+    "\\mathsfbf{h}",
+    "𝗵 mathematical sans-serif bold small h"
+  ],
+  [
+    "\\mathsfbf{i}",
+    "𝗶 mathematical sans-serif bold small i"
+  ],
+  [
+    "\\mathsfbf{j}",
+    "𝗷 mathematical sans-serif bold small j"
+  ],
+  [
+    "\\mathsfbf{k}",
+    "𝗸 mathematical sans-serif bold small k"
+  ],
+  [
+    "\\mathsfbf{l}",
+    "𝗹 mathematical sans-serif bold small l"
+  ],
+  [
+    "\\mathsfbf{m}",
+    "𝗺 mathematical sans-serif bold small m"
+  ],
+  [
+    "\\mathsfbf{n}",
+    "𝗻 mathematical sans-serif bold small n"
+  ],
+  [
+    "\\mathsfbf{o}",
+    "𝗼 mathematical sans-serif bold small o"
+  ],
+  [
+    "\\mathsfbf{p}",
+    "𝗽 mathematical sans-serif bold small p"
+  ],
+  [
+    "\\mathsfbf{q}",
+    "𝗾 mathematical sans-serif bold small q"
+  ],
+  [
+    "\\mathsfbf{r}",
+    "𝗿 mathematical sans-serif bold small r"
+  ],
+  [
+    "\\mathsfbf{s}",
+    "𝘀 mathematical sans-serif bold small s"
+  ],
+  [
+    "\\mathsfbf{t}",
+    "𝘁 mathematical sans-serif bold small t"
+  ],
+  [
+    "\\mathsfbf{u}",
+    "𝘂 mathematical sans-serif bold small u"
+  ],
+  [
+    "\\mathsfbf{v}",
+    "𝘃 mathematical sans-serif bold small v"
+  ],
+  [
+    "\\mathsfbf{w}",
+    "𝘄 mathematical sans-serif bold small w"
+  ],
+  [
+    "\\mathsfbf{x}",
+    "𝘅 mathematical sans-serif bold small x"
+  ],
+  [
+    "\\mathsfbf{y}",
+    "𝘆 mathematical sans-serif bold small y"
+  ],
+  [
+    "\\mathsfbf{z}",
+    "𝘇 mathematical sans-serif bold small z"
+  ],
+  [
+    "\\mathsfit{A}",
+    "𝘈 mathematical sans-serif italic capital a"
+  ],
+  [
+    "\\mathsfit{B}",
+    "𝘉 mathematical sans-serif italic capital b"
+  ],
+  [
+    "\\mathsfit{C}",
+    "𝘊 mathematical sans-serif italic capital c"
+  ],
+  [
+    "\\mathsfit{D}",
+    "𝘋 mathematical sans-serif italic capital d"
+  ],
+  [
+    "\\mathsfit{E}",
+    "𝘌 mathematical sans-serif italic capital e"
+  ],
+  [
+    "\\mathsfit{F}",
+    "𝘍 mathematical sans-serif italic capital f"
+  ],
+  [
+    "\\mathsfit{G}",
+    "𝘎 mathematical sans-serif italic capital g"
+  ],
+  [
+    "\\mathsfit{H}",
+    "𝘏 mathematical sans-serif italic capital h"
+  ],
+  [
+    "\\mathsfit{I}",
+    "𝘐 mathematical sans-serif italic capital i"
+  ],
+  [
+    "\\mathsfit{J}",
+    "𝘑 mathematical sans-serif italic capital j"
+  ],
+  [
+    "\\mathsfit{K}",
+    "𝘒 mathematical sans-serif italic capital k"
+  ],
+  [
+    "\\mathsfit{L}",
+    "𝘓 mathematical sans-serif italic capital l"
+  ],
+  [
+    "\\mathsfit{M}",
+    "𝘔 mathematical sans-serif italic capital m"
+  ],
+  [
+    "\\mathsfit{N}",
+    "𝘕 mathematical sans-serif italic capital n"
+  ],
+  [
+    "\\mathsfit{O}",
+    "𝘖 mathematical sans-serif italic capital o"
+  ],
+  [
+    "\\mathsfit{P}",
+    "𝘗 mathematical sans-serif italic capital p"
+  ],
+  [
+    "\\mathsfit{Q}",
+    "𝘘 mathematical sans-serif italic capital q"
+  ],
+  [
+    "\\mathsfit{R}",
+    "𝘙 mathematical sans-serif italic capital r"
+  ],
+  [
+    "\\mathsfit{S}",
+    "𝘚 mathematical sans-serif italic capital s"
+  ],
+  [
+    "\\mathsfit{T}",
+    "𝘛 mathematical sans-serif italic capital t"
+  ],
+  [
+    "\\mathsfit{U}",
+    "𝘜 mathematical sans-serif italic capital u"
+  ],
+  [
+    "\\mathsfit{V}",
+    "𝘝 mathematical sans-serif italic capital v"
+  ],
+  [
+    "\\mathsfit{W}",
+    "𝘞 mathematical sans-serif italic capital w"
+  ],
+  [
+    "\\mathsfit{X}",
+    "𝘟 mathematical sans-serif italic capital x"
+  ],
+  [
+    "\\mathsfit{Y}",
+    "𝘠 mathematical sans-serif italic capital y"
+  ],
+  [
+    "\\mathsfit{Z}",
+    "𝘡 mathematical sans-serif italic capital z"
+  ],
+  [
+    "\\mathsfit{a}",
+    "𝘢 mathematical sans-serif italic small a"
+  ],
+  [
+    "\\mathsfit{b}",
+    "𝘣 mathematical sans-serif italic small b"
+  ],
+  [
+    "\\mathsfit{c}",
+    "𝘤 mathematical sans-serif italic small c"
+  ],
+  [
+    "\\mathsfit{d}",
+    "𝘥 mathematical sans-serif italic small d"
+  ],
+  [
+    "\\mathsfit{e}",
+    "𝘦 mathematical sans-serif italic small e"
+  ],
+  [
+    "\\mathsfit{f}",
+    "𝘧 mathematical sans-serif italic small f"
+  ],
+  [
+    "\\mathsfit{g}",
+    "𝘨 mathematical sans-serif italic small g"
+  ],
+  [
+    "\\mathsfit{h}",
+    "𝘩 mathematical sans-serif italic small h"
+  ],
+  [
+    "\\mathsfit{i}",
+    "𝘪 mathematical sans-serif italic small i"
+  ],
+  [
+    "\\mathsfit{j}",
+    "𝘫 mathematical sans-serif italic small j"
+  ],
+  [
+    "\\mathsfit{k}",
+    "𝘬 mathematical sans-serif italic small k"
+  ],
+  [
+    "\\mathsfit{l}",
+    "𝘭 mathematical sans-serif italic small l"
+  ],
+  [
+    "\\mathsfit{m}",
+    "𝘮 mathematical sans-serif italic small m"
+  ],
+  [
+    "\\mathsfit{n}",
+    "𝘯 mathematical sans-serif italic small n"
+  ],
+  [
+    "\\mathsfit{o}",
+    "𝘰 mathematical sans-serif italic small o"
+  ],
+  [
+    "\\mathsfit{p}",
+    "𝘱 mathematical sans-serif italic small p"
+  ],
+  [
+    "\\mathsfit{q}",
+    "𝘲 mathematical sans-serif italic small q"
+  ],
+  [
+    "\\mathsfit{r}",
+    "𝘳 mathematical sans-serif italic small r"
+  ],
+  [
+    "\\mathsfit{s}",
+    "𝘴 mathematical sans-serif italic small s"
+  ],
+  [
+    "\\mathsfit{t}",
+    "𝘵 mathematical sans-serif italic small t"
+  ],
+  [
+    "\\mathsfit{u}",
+    "𝘶 mathematical sans-serif italic small u"
+  ],
+  [
+    "\\mathsfit{v}",
+    "𝘷 mathematical sans-serif italic small v"
+  ],
+  [
+    "\\mathsfit{w}",
+    "𝘸 mathematical sans-serif italic small w"
+  ],
+  [
+    "\\mathsfit{x}",
+    "𝘹 mathematical sans-serif italic small x"
+  ],
+  [
+    "\\mathsfit{y}",
+    "𝘺 mathematical sans-serif italic small y"
+  ],
+  [
+    "\\mathsfit{z}",
+    "𝘻 mathematical sans-serif italic small z"
+  ],
+  [
+    "\\mathsfbfit{A}",
+    "𝘼 mathematical sans-serif bold italic capital a"
+  ],
+  [
+    "\\mathsfbfit{B}",
+    "𝘽 mathematical sans-serif bold italic capital b"
+  ],
+  [
+    "\\mathsfbfit{C}",
+    "𝘾 mathematical sans-serif bold italic capital c"
+  ],
+  [
+    "\\mathsfbfit{D}",
+    "𝘿 mathematical sans-serif bold italic capital d"
+  ],
+  [
+    "\\mathsfbfit{E}",
+    "𝙀 mathematical sans-serif bold italic capital e"
+  ],
+  [
+    "\\mathsfbfit{F}",
+    "𝙁 mathematical sans-serif bold italic capital f"
+  ],
+  [
+    "\\mathsfbfit{G}",
+    "𝙂 mathematical sans-serif bold italic capital g"
+  ],
+  [
+    "\\mathsfbfit{H}",
+    "𝙃 mathematical sans-serif bold italic capital h"
+  ],
+  [
+    "\\mathsfbfit{I}",
+    "𝙄 mathematical sans-serif bold italic capital i"
+  ],
+  [
+    "\\mathsfbfit{J}",
+    "𝙅 mathematical sans-serif bold italic capital j"
+  ],
+  [
+    "\\mathsfbfit{K}",
+    "𝙆 mathematical sans-serif bold italic capital k"
+  ],
+  [
+    "\\mathsfbfit{L}",
+    "𝙇 mathematical sans-serif bold italic capital l"
+  ],
+  [
+    "\\mathsfbfit{M}",
+    "𝙈 mathematical sans-serif bold italic capital m"
+  ],
+  [
+    "\\mathsfbfit{N}",
+    "𝙉 mathematical sans-serif bold italic capital n"
+  ],
+  [
+    "\\mathsfbfit{O}",
+    "𝙊 mathematical sans-serif bold italic capital o"
+  ],
+  [
+    "\\mathsfbfit{P}",
+    "𝙋 mathematical sans-serif bold italic capital p"
+  ],
+  [
+    "\\mathsfbfit{Q}",
+    "𝙌 mathematical sans-serif bold italic capital q"
+  ],
+  [
+    "\\mathsfbfit{R}",
+    "𝙍 mathematical sans-serif bold italic capital r"
+  ],
+  [
+    "\\mathsfbfit{S}",
+    "𝙎 mathematical sans-serif bold italic capital s"
+  ],
+  [
+    "\\mathsfbfit{T}",
+    "𝙏 mathematical sans-serif bold italic capital t"
+  ],
+  [
+    "\\mathsfbfit{U}",
+    "𝙐 mathematical sans-serif bold italic capital u"
+  ],
+  [
+    "\\mathsfbfit{V}",
+    "𝙑 mathematical sans-serif bold italic capital v"
+  ],
+  [
+    "\\mathsfbfit{W}",
+    "𝙒 mathematical sans-serif bold italic capital w"
+  ],
+  [
+    "\\mathsfbfit{X}",
+    "𝙓 mathematical sans-serif bold italic capital x"
+  ],
+  [
+    "\\mathsfbfit{Y}",
+    "𝙔 mathematical sans-serif bold italic capital y"
+  ],
+  [
+    "\\mathsfbfit{Z}",
+    "𝙕 mathematical sans-serif bold italic capital z"
+  ],
+  [
+    "\\mathsfbfit{a}",
+    "𝙖 mathematical sans-serif bold italic small a"
+  ],
+  [
+    "\\mathsfbfit{b}",
+    "𝙗 mathematical sans-serif bold italic small b"
+  ],
+  [
+    "\\mathsfbfit{c}",
+    "𝙘 mathematical sans-serif bold italic small c"
+  ],
+  [
+    "\\mathsfbfit{d}",
+    "𝙙 mathematical sans-serif bold italic small d"
+  ],
+  [
+    "\\mathsfbfit{e}",
+    "𝙚 mathematical sans-serif bold italic small e"
+  ],
+  [
+    "\\mathsfbfit{f}",
+    "𝙛 mathematical sans-serif bold italic small f"
+  ],
+  [
+    "\\mathsfbfit{g}",
+    "𝙜 mathematical sans-serif bold italic small g"
+  ],
+  [
+    "\\mathsfbfit{h}",
+    "𝙝 mathematical sans-serif bold italic small h"
+  ],
+  [
+    "\\mathsfbfit{i}",
+    "𝙞 mathematical sans-serif bold italic small i"
+  ],
+  [
+    "\\mathsfbfit{j}",
+    "𝙟 mathematical sans-serif bold italic small j"
+  ],
+  [
+    "\\mathsfbfit{k}",
+    "𝙠 mathematical sans-serif bold italic small k"
+  ],
+  [
+    "\\mathsfbfit{l}",
+    "𝙡 mathematical sans-serif bold italic small l"
+  ],
+  [
+    "\\mathsfbfit{m}",
+    "𝙢 mathematical sans-serif bold italic small m"
+  ],
+  [
+    "\\mathsfbfit{n}",
+    "𝙣 mathematical sans-serif bold italic small n"
+  ],
+  [
+    "\\mathsfbfit{o}",
+    "𝙤 mathematical sans-serif bold italic small o"
+  ],
+  [
+    "\\mathsfbfit{p}",
+    "𝙥 mathematical sans-serif bold italic small p"
+  ],
+  [
+    "\\mathsfbfit{q}",
+    "𝙦 mathematical sans-serif bold italic small q"
+  ],
+  [
+    "\\mathsfbfit{r}",
+    "𝙧 mathematical sans-serif bold italic small r"
+  ],
+  [
+    "\\mathsfbfit{s}",
+    "𝙨 mathematical sans-serif bold italic small s"
+  ],
+  [
+    "\\mathsfbfit{t}",
+    "𝙩 mathematical sans-serif bold italic small t"
+  ],
+  [
+    "\\mathsfbfit{u}",
+    "𝙪 mathematical sans-serif bold italic small u"
+  ],
+  [
+    "\\mathsfbfit{v}",
+    "𝙫 mathematical sans-serif bold italic small v"
+  ],
+  [
+    "\\mathsfbfit{w}",
+    "𝙬 mathematical sans-serif bold italic small w"
+  ],
+  [
+    "\\mathsfbfit{x}",
+    "𝙭 mathematical sans-serif bold italic small x"
+  ],
+  [
+    "\\mathsfbfit{y}",
+    "𝙮 mathematical sans-serif bold italic small y"
+  ],
+  [
+    "\\mathsfbfit{z}",
+    "𝙯 mathematical sans-serif bold italic small z"
+  ],
+  [
+    "\\mathtt{A}",
+    "𝙰 mathematical monospace capital a"
+  ],
+  [
+    "\\mathtt{B}",
+    "𝙱 mathematical monospace capital b"
+  ],
+  [
+    "\\mathtt{C}",
+    "𝙲 mathematical monospace capital c"
+  ],
+  [
+    "\\mathtt{D}",
+    "𝙳 mathematical monospace capital d"
+  ],
+  [
+    "\\mathtt{E}",
+    "𝙴 mathematical monospace capital e"
+  ],
+  [
+    "\\mathtt{F}",
+    "𝙵 mathematical monospace capital f"
+  ],
+  [
+    "\\mathtt{G}",
+    "𝙶 mathematical monospace capital g"
+  ],
+  [
+    "\\mathtt{H}",
+    "𝙷 mathematical monospace capital h"
+  ],
+  [
+    "\\mathtt{I}",
+    "𝙸 mathematical monospace capital i"
+  ],
+  [
+    "\\mathtt{J}",
+    "𝙹 mathematical monospace capital j"
+  ],
+  [
+    "\\mathtt{K}",
+    "𝙺 mathematical monospace capital k"
+  ],
+  [
+    "\\mathtt{L}",
+    "𝙻 mathematical monospace capital l"
+  ],
+  [
+    "\\mathtt{M}",
+    "𝙼 mathematical monospace capital m"
+  ],
+  [
+    "\\mathtt{N}",
+    "𝙽 mathematical monospace capital n"
+  ],
+  [
+    "\\mathtt{O}",
+    "𝙾 mathematical monospace capital o"
+  ],
+  [
+    "\\mathtt{P}",
+    "𝙿 mathematical monospace capital p"
+  ],
+  [
+    "\\mathtt{Q}",
+    "𝚀 mathematical monospace capital q"
+  ],
+  [
+    "\\mathtt{R}",
+    "𝚁 mathematical monospace capital r"
+  ],
+  [
+    "\\mathtt{S}",
+    "𝚂 mathematical monospace capital s"
+  ],
+  [
+    "\\mathtt{T}",
+    "𝚃 mathematical monospace capital t"
+  ],
+  [
+    "\\mathtt{U}",
+    "𝚄 mathematical monospace capital u"
+  ],
+  [
+    "\\mathtt{V}",
+    "𝚅 mathematical monospace capital v"
+  ],
+  [
+    "\\mathtt{W}",
+    "𝚆 mathematical monospace capital w"
+  ],
+  [
+    "\\mathtt{X}",
+    "𝚇 mathematical monospace capital x"
+  ],
+  [
+    "\\mathtt{Y}",
+    "𝚈 mathematical monospace capital y"
+  ],
+  [
+    "\\mathtt{Z}",
+    "𝚉 mathematical monospace capital z"
+  ],
+  [
+    "\\mathtt{a}",
+    "𝚊 mathematical monospace small a"
+  ],
+  [
+    "\\mathtt{b}",
+    "𝚋 mathematical monospace small b"
+  ],
+  [
+    "\\mathtt{c}",
+    "𝚌 mathematical monospace small c"
+  ],
+  [
+    "\\mathtt{d}",
+    "𝚍 mathematical monospace small d"
+  ],
+  [
+    "\\mathtt{e}",
+    "𝚎 mathematical monospace small e"
+  ],
+  [
+    "\\mathtt{f}",
+    "𝚏 mathematical monospace small f"
+  ],
+  [
+    "\\mathtt{g}",
+    "𝚐 mathematical monospace small g"
+  ],
+  [
+    "\\mathtt{h}",
+    "𝚑 mathematical monospace small h"
+  ],
+  [
+    "\\mathtt{i}",
+    "𝚒 mathematical monospace small i"
+  ],
+  [
+    "\\mathtt{j}",
+    "𝚓 mathematical monospace small j"
+  ],
+  [
+    "\\mathtt{k}",
+    "𝚔 mathematical monospace small k"
+  ],
+  [
+    "\\mathtt{l}",
+    "𝚕 mathematical monospace small l"
+  ],
+  [
+    "\\mathtt{m}",
+    "𝚖 mathematical monospace small m"
+  ],
+  [
+    "\\mathtt{n}",
+    "𝚗 mathematical monospace small n"
+  ],
+  [
+    "\\mathtt{o}",
+    "𝚘 mathematical monospace small o"
+  ],
+  [
+    "\\mathtt{p}",
+    "𝚙 mathematical monospace small p"
+  ],
+  [
+    "\\mathtt{q}",
+    "𝚚 mathematical monospace small q"
+  ],
+  [
+    "\\mathtt{r}",
+    "𝚛 mathematical monospace small r"
+  ],
+  [
+    "\\mathtt{s}",
+    "𝚜 mathematical monospace small s"
+  ],
+  [
+    "\\mathtt{t}",
+    "𝚝 mathematical monospace small t"
+  ],
+  [
+    "\\mathtt{u}",
+    "𝚞 mathematical monospace small u"
+  ],
+  [
+    "\\mathtt{v}",
+    "𝚟 mathematical monospace small v"
+  ],
+  [
+    "\\mathtt{w}",
+    "𝚠 mathematical monospace small w"
+  ],
+  [
+    "\\mathtt{x}",
+    "𝚡 mathematical monospace small x"
+  ],
+  [
+    "\\mathtt{y}",
+    "𝚢 mathematical monospace small y"
+  ],
+  [
+    "\\mathtt{z}",
+    "𝚣 mathematical monospace small z"
+  ],
+  [
+    "\\imath",
+    "𝚤 mathematical italic small dotless i"
+  ],
+  [
+    "\\jmath",
+    "𝚥 mathematical italic small dotless j"
   ],
   [
     "\\mbfAlpha",
-    "mathematical bold capital alpha"
+    "𝚨  mathematical bold capital alpha"
   ],
   [
     "\\mbfBeta",
-    "mathematical bold capital beta"
+    "𝚩  mathematical bold capital beta"
   ],
   [
-    "\\mbfGamma",
-    "mathematical bold capital gamma"
+    "\\mathbf{\\Gamma}",
+    "𝚪 mathematical bold capital gamma"
   ],
   [
-    "\\mbfDelta",
-    "mathematical bold capital delta"
+    "\\mathbf{\\Delta}",
+    "𝚫 mathematical bold capital delta"
   ],
   [
     "\\mbfEpsilon",
-    "mathematical bold capital epsilon"
+    "𝚬  mathematical bold capital epsilon"
   ],
   [
     "\\mbfZeta",
-    "mathematical bold capital zeta"
+    "𝚭  mathematical bold capital zeta"
   ],
   [
     "\\mbfEta",
-    "mathematical bold capital eta"
+    "𝚮  mathematical bold capital eta"
   ],
   [
-    "\\mbfTheta",
-    "mathematical bold capital theta"
+    "\\mathbf{\\Theta}",
+    "𝚯 mathematical bold capital theta"
   ],
   [
     "\\mbfIota",
-    "mathematical bold capital iota"
+    "𝚰  mathematical bold capital iota"
   ],
   [
     "\\mbfKappa",
-    "mathematical bold capital kappa"
+    "𝚱  mathematical bold capital kappa"
   ],
   [
-    "\\mbfLambda",
-    "mathematical bold capital lambda"
+    "\\mathbf{\\Lambda}",
+    "𝚲 mathematical bold capital lambda"
   ],
   [
     "\\mbfMu",
-    "mathematical bold capital mu"
+    "𝚳  mathematical bold capital mu"
   ],
   [
     "\\mbfNu",
-    "mathematical bold capital nu"
+    "𝚴  mathematical bold capital nu"
   ],
   [
-    "\\mbfXi",
-    "mathematical bold capital xi"
+    "\\mathbf{\\Xi}",
+    "𝚵 mathematical bold capital xi"
   ],
   [
     "\\mbfOmicron",
-    "mathematical bold capital omicron"
+    "𝚶  mathematical bold capital omicron"
   ],
   [
-    "\\mbfPi",
-    "mathematical bold capital pi"
+    "\\mathbf{\\Pi}",
+    "𝚷 mathematical bold capital pi"
   ],
   [
     "\\mbfRho",
-    "mathematical bold capital rho"
+    "𝚸  mathematical bold capital rho"
   ],
   [
     "\\mbfvarTheta",
-    "mathematical bold capital theta symbol"
+    "𝚹  mathematical bold capital theta symbol"
   ],
   [
-    "\\mbfSigma",
-    "mathematical bold capital sigma"
+    "\\mathbf{\\Sigma}",
+    "𝚺 mathematical bold capital sigma"
   ],
   [
     "\\mbfTau",
-    "mathematical bold capital tau"
+    "𝚻  mathematical bold capital tau"
   ],
   [
-    "\\mbfUpsilon",
-    "mathematical bold capital upsilon"
+    "\\mathbf{\\Upsilon}",
+    "𝚼 mathematical bold capital upsilon"
   ],
   [
-    "\\mbfPhi",
-    "mathematical bold capital phi"
+    "\\mathbf{\\Phi}",
+    "𝚽 mathematical bold capital phi"
   ],
   [
     "\\mbfChi",
-    "mathematical bold capital chi"
+    "𝚾  mathematical bold capital chi"
   ],
   [
-    "\\mbfPsi",
-    "mathematical bold capital psi"
+    "\\mathbf{\\Psi}",
+    "𝚿 mathematical bold capital psi"
   ],
   [
-    "\\mbfOmega",
-    "mathematical bold capital omega"
+    "\\mathbf{\\Omega}",
+    "𝛀 mathematical bold capital omega"
   ],
   [
     "\\mbfnabla",
-    "mathematical bold nabla"
+    "𝛁  mathematical bold nabla"
   ],
   [
-    "\\mbfalpha",
-    "mathematical bold small alpha"
+    "\\mathbf{\\alpha}",
+    "𝛂 mathematical bold small alpha"
   ],
   [
-    "\\mbfbeta",
-    "mathematical bold small beta"
+    "\\mathbf{\\beta}",
+    "𝛃 mathematical bold small beta"
   ],
   [
-    "\\mbfgamma",
-    "mathematical bold small gamma"
+    "\\mathbf{\\gamma}",
+    "𝛄 mathematical bold small gamma"
   ],
   [
-    "\\mbfdelta",
-    "mathematical bold small delta"
+    "\\mathbf{\\delta}",
+    "𝛅 mathematical bold small delta"
   ],
   [
-    "\\mbfvarepsilon",
-    "mathematical bold small varepsilon"
+    "\\mathbf{\\varepsilon}",
+    "𝛆 mathematical bold small epsilon"
   ],
   [
-    "\\mbfzeta",
-    "mathematical bold small zeta"
+    "\\mathbf{\\zeta}",
+    "𝛇 mathematical bold small zeta"
   ],
   [
-    "\\mbfeta",
-    "mathematical bold small eta"
+    "\\mathbf{\\eta}",
+    "𝛈 mathematical bold small eta"
   ],
   [
-    "\\mbftheta",
-    "mathematical bold small theta"
+    "\\mathbf{\\theta}",
+    "𝛉 mathematical bold small theta"
   ],
   [
-    "\\mbfiota",
-    "mathematical bold small iota"
+    "\\mathbf{\\iota}",
+    "𝛊 mathematical bold small iota"
   ],
   [
-    "\\mbfkappa",
-    "mathematical bold small kappa"
+    "\\mathbf{\\kappa}",
+    "𝛋 mathematical bold small kappa"
   ],
   [
-    "\\mbflambda",
-    "mathematical bold small lambda"
+    "\\mathbf{\\lambda}",
+    "𝛌 mathematical bold small lambda"
   ],
   [
-    "\\mbfmu",
-    "mathematical bold small mu"
+    "\\mathbf{\\mu}",
+    "𝛍 mathematical bold small mu"
   ],
   [
-    "\\mbfnu",
-    "mathematical bold small nu"
+    "\\mathbf{\\nu}",
+    "𝛎 mathematical bold small nu"
   ],
   [
-    "\\mbfxi",
-    "mathematical bold small xi"
+    "\\mathbf{\\xi}",
+    "𝛏 mathematical bold small xi"
   ],
   [
     "\\mbfomicron",
-    "mathematical bold small omicron"
+    "𝛐  mathematical bold small omicron"
   ],
   [
-    "\\mbfpi",
-    "mathematical bold small pi"
+    "\\mathbf{\\pi}",
+    "𝛑 mathematical bold small pi"
   ],
   [
-    "\\mbfrho",
-    "mathematical bold small rho"
+    "\\mathbf{\\rho}",
+    "𝛒 mathematical bold small rho"
   ],
   [
-    "\\mbfvarsigma",
-    "mathematical bold small final sigma"
+    "\\mathbf{\\varsigma}",
+    "𝛓 mathematical bold small final sigma"
   ],
   [
-    "\\mbfsigma",
-    "mathematical bold small sigma"
+    "\\mathbf{\\sigma}",
+    "𝛔 mathematical bold small sigma"
   ],
   [
-    "\\mbftau",
-    "mathematical bold small tau"
+    "\\mathbf{\\tau}",
+    "𝛕 mathematical bold small tau"
   ],
   [
-    "\\mbfupsilon",
-    "mathematical bold small upsilon"
+    "\\mathbf{\\upsilon}",
+    "𝛖 mathematical bold small upsilon"
   ],
   [
-    "\\mbfvarphi",
-    "mathematical bold small phi"
+    "\\mathbf{\\varphi}",
+    "𝛗 mathematical bold small phi"
   ],
   [
-    "\\mbfchi",
-    "mathematical bold small chi"
+    "\\mathbf{\\chi}",
+    "𝛘 mathematical bold small chi"
   ],
   [
-    "\\mbfpsi",
-    "mathematical bold small psi"
+    "\\mathbf{\\psi}",
+    "𝛙 mathematical bold small psi"
   ],
   [
-    "\\mbfomega",
-    "mathematical bold small omega"
+    "\\mathbf{\\omega}",
+    "𝛚 mathematical bold small omega"
   ],
   [
     "\\mbfpartial",
-    "mathematical bold partial differential"
+    "𝛛  mathematical bold partial differential"
   ],
   [
-    "\\mbfepsilon",
-    "mathematical bold varepsilon symbol"
+    "\\mathbf{\\epsilon}",
+    "𝛜 mathematical bold epsilon symbol"
   ],
   [
-    "\\mbfvartheta",
-    "mathematical bold theta symbol"
+    "\\mathbf{\\vartheta}",
+    "𝛝 mathematical bold theta symbol"
   ],
   [
     "\\mbfvarkappa",
-    "mathematical bold kappa symbol"
+    "𝛞  mathematical bold kappa symbol"
   ],
   [
-    "\\mbfphi",
-    "mathematical bold phi symbol"
+    "\\mathbf{\\phi}",
+    "𝛟 mathematical bold phi symbol"
   ],
   [
-    "\\mbfvarrho",
-    "mathematical bold rho symbol"
+    "\\mathbf{\\varrho}",
+    "𝛠 mathematical bold rho symbol"
   ],
   [
-    "\\mbfvarpi",
-    "mathematical bold pi symbol"
+    "\\mathbf{\\varpi}",
+    "𝛡 mathematical bold pi symbol"
   ],
   [
     "\\mitAlpha",
-    "mathematical italic capital alpha"
+    "𝛢  mathematical italic capital alpha"
   ],
   [
     "\\mitBeta",
-    "mathematical italic capital beta"
+    "𝛣  mathematical italic capital beta"
   ],
   [
-    "\\mitGamma",
-    "mathematical italic capital gamma"
+    "\\Gamma",
+    "𝛤 = \\mathit{\\gamma} (-fourier), = \\vargamma (amsmath fourier), mathematical italic capital gamma"
   ],
   [
-    "\\mitDelta",
-    "mathematical italic capital delta"
+    "\\Delta",
+    "𝛥 = \\mathit{\\delta} (-fourier), = \\vardelta (amsmath fourier), mathematical italic capital delta"
   ],
   [
     "\\mitEpsilon",
-    "mathematical italic capital epsilon"
+    "𝛦  mathematical italic capital epsilon"
   ],
   [
     "\\mitZeta",
-    "mathematical italic capital zeta"
+    "𝛧  mathematical italic capital zeta"
   ],
   [
     "\\mitEta",
-    "mathematical italic capital eta"
+    "𝛨  mathematical italic capital eta"
   ],
   [
-    "\\mitTheta",
-    "mathematical italic capital theta"
+    "\\Theta",
+    "𝛩 = \\mathit{\\theta} (-fourier), = \\vartheta (amsmath fourier), mathematical italic capital theta"
   ],
   [
     "\\mitIota",
-    "mathematical italic capital iota"
+    "𝛪  mathematical italic capital iota"
   ],
   [
     "\\mitKappa",
-    "mathematical italic capital kappa"
+    "𝛫  mathematical italic capital kappa"
   ],
   [
-    "\\mitLambda",
-    "mathematical italic capital lambda"
+    "\\Lambda",
+    "𝛬 = \\mathit{\\lambda} (-fourier), = \\varlambda (amsmath fourier), mathematical italic capital lambda"
   ],
   [
     "\\mitMu",
-    "mathematical italic capital mu"
+    "𝛭  mathematical italic capital mu"
   ],
   [
     "\\mitNu",
-    "mathematical italic capital nu"
+    "𝛮  mathematical italic capital nu"
   ],
   [
-    "\\mitXi",
-    "mathematical italic capital xi"
+    "\\Xi",
+    "𝛯 = \\mathit{\\xi} (-fourier), = \\varxi (amsmath fourier), mathematical italic capital xi"
   ],
   [
     "\\mitOmicron",
-    "mathematical italic capital omicron"
+    "𝛰  mathematical italic capital omicron"
   ],
   [
-    "\\mitPi",
-    "mathematical italic capital pi"
+    "\\Pi",
+    "𝛱 = \\mathit{\\pi} (-fourier), = \\varpi (amsmath fourier), mathematical italic capital pi"
   ],
   [
     "\\mitRho",
-    "mathematical italic capital rho"
+    "𝛲  mathematical italic capital rho"
   ],
   [
     "\\mitvarTheta",
-    "mathematical italic capital theta symbol"
+    "𝛳  mathematical italic capital theta symbol"
   ],
   [
-    "\\mitSigma",
-    "mathematical italic capital sigma"
+    "\\Sigma",
+    "𝛴 = \\mathit{\\sigma} (-fourier), = \\varsigma (amsmath fourier), mathematical italic capital sigma"
   ],
   [
     "\\mitTau",
-    "mathematical italic capital tau"
+    "𝛵  mathematical italic capital tau"
   ],
   [
-    "\\mitUpsilon",
-    "mathematical italic capital upsilon"
+    "\\Upsilon",
+    "𝛶 = \\mathit{\\upsilon} (-fourier), = \\varupsilon (amsmath fourier), mathematical italic capital upsilon"
   ],
   [
-    "\\mitPhi",
-    "mathematical italic capital phi"
+    "\\Phi",
+    "𝛷 = \\mathit{\\phi} (-fourier), = \\varphi (amsmath fourier), mathematical italic capital phi"
   ],
   [
     "\\mitChi",
-    "mathematical italic capital chi"
+    "𝛸  mathematical italic capital chi"
   ],
   [
-    "\\mitPsi",
-    "mathematical italic capital psi"
+    "\\Psi",
+    "𝛹 = \\mathit{\\psi} (-fourier), = \\varpsi (amsmath fourier), mathematical italic capital psi"
   ],
   [
-    "\\mitOmega",
-    "mathematical italic capital omega"
+    "\\Omega",
+    "𝛺 = \\mathit{\\omega} (-fourier), = \\varomega (amsmath fourier), mathematical italic capital omega"
   ],
   [
     "\\mitnabla",
-    "mathematical italic nabla"
+    "𝛻  mathematical italic nabla"
   ],
   [
-    "\\mitalpha",
-    "mathematical italic small alpha"
+    "\\alpha",
+    "𝛼 = \\mathit{\\alpha} (omlmathit), mathematical italic small alpha"
   ],
   [
-    "\\mitbeta",
-    "mathematical italic small beta"
+    "\\beta",
+    "𝛽 = \\mathit{\\beta} (omlmathit), mathematical italic small beta"
   ],
   [
-    "\\mitgamma",
-    "mathematical italic small gamma"
+    "\\gamma",
+    "𝛾 = \\mathit{\\gamma} (omlmathit), mathematical italic small gamma"
   ],
   [
-    "\\mitdelta",
-    "mathematical italic small delta"
+    "\\delta",
+    "𝛿 = \\mathit{\\delta} (omlmathit), mathematical italic small delta"
   ],
   [
-    "\\mitvarepsilon",
-    "mathematical italic small varepsilon"
+    "\\varepsilon",
+    "𝜀 = \\mathit{\\varepsilon} (omlmathit), mathematical italic small epsilon"
   ],
   [
-    "\\mitzeta",
-    "mathematical italic small zeta"
+    "\\zeta",
+    "𝜁 = \\mathit{\\zeta} (omlmathit), mathematical italic small zeta"
   ],
   [
-    "\\miteta",
-    "mathematical italic small eta"
+    "\\eta",
+    "𝜂 = \\mathit{\\eta} (omlmathit), mathematical italic small eta"
   ],
   [
-    "\\mittheta",
-    "mathematical italic small theta"
+    "\\theta",
+    "𝜃 = \\mathit{\\theta} (omlmathit), mathematical italic small theta"
   ],
   [
-    "\\mitiota",
-    "mathematical italic small iota"
+    "\\iota",
+    "𝜄 = \\mathit{\\iota} (omlmathit), mathematical italic small iota"
   ],
   [
-    "\\mitkappa",
-    "mathematical italic small kappa"
+    "\\kappa",
+    "𝜅 = \\mathit{\\kappa} (omlmathit), mathematical italic small kappa"
   ],
   [
-    "\\mitlambda",
-    "mathematical italic small lambda"
+    "\\lambda",
+    "𝜆 = \\mathit{\\lambda} (omlmathit), mathematical italic small lambda"
   ],
   [
-    "\\mitmu",
-    "mathematical italic small mu"
+    "\\mu",
+    "𝜇 = \\mathit{\\mu} (omlmathit), mathematical italic small mu"
   ],
   [
-    "\\mitnu",
-    "mathematical italic small nu"
+    "\\nu",
+    "𝜈 = \\mathit{\\nu} (omlmathit), mathematical italic small nu"
   ],
   [
-    "\\mitxi",
-    "mathematical italic small xi"
+    "\\xi",
+    "𝜉 = \\mathit{\\xi} (omlmathit), mathematical italic small xi"
   ],
   [
     "\\mitomicron",
-    "mathematical italic small omicron"
+    "𝜊  mathematical italic small omicron"
   ],
   [
-    "\\mitpi",
-    "mathematical italic small pi"
+    "\\pi",
+    "𝜋 = \\mathit{\\pi} (omlmathit), mathematical italic small pi"
   ],
   [
-    "\\mitrho",
-    "mathematical italic small rho"
+    "\\rho",
+    "𝜌 = \\mathit{\\rho} (omlmathit), mathematical italic small rho"
   ],
   [
-    "\\mitvarsigma",
-    "mathematical italic small final sigma"
+    "\\varsigma",
+    "𝜍 = \\mathit{\\varsigma} (omlmathit), mathematical italic small final sigma"
   ],
   [
-    "\\mitsigma",
-    "mathematical italic small sigma"
+    "\\sigma",
+    "𝜎 = \\mathit{\\sigma} (omlmathit), mathematical italic small sigma"
   ],
   [
-    "\\mittau",
-    "mathematical italic small tau"
+    "\\tau",
+    "𝜏 = \\mathit{\\tau} (omlmathit), mathematical italic small tau"
   ],
   [
-    "\\mitupsilon",
-    "mathematical italic small upsilon"
+    "\\upsilon",
+    "𝜐 = \\mathit{\\upsilon} (omlmathit), mathematical italic small upsilon"
   ],
   [
-    "\\mitvarphi",
-    "mathematical italic small phi"
+    "\\varphi",
+    "𝜑 = \\mathit{\\varphi} (omlmathit), mathematical italic small phi"
   ],
   [
-    "\\mitchi",
-    "mathematical italic small chi"
+    "\\chi",
+    "𝜒 = \\mathit{\\chi} (omlmathit), mathematical italic small chi"
   ],
   [
-    "\\mitpsi",
-    "mathematical italic small psi"
+    "\\psi",
+    "𝜓 = \\mathit{\\psi} (omlmathit), mathematical italic small psi"
   ],
   [
-    "\\mitomega",
-    "mathematical italic small omega"
+    "\\omega",
+    "𝜔 = \\mathit{\\omega} (omlmathit), mathematical italic small omega"
   ],
   [
-    "\\mitpartial",
-    "mathematical italic partial differential"
+    "\\partial",
+    "𝜕 = \\mathit{\\partial} (omlmathit), mathematical italic partial differential"
   ],
   [
-    "\\mitepsilon",
-    "mathematical italic varepsilon symbol"
+    "\\epsilon",
+    "𝜖 = \\mathit{\\epsilon} (omlmathit), mathematical italic epsilon symbol"
   ],
   [
-    "\\mitvartheta",
-    "mathematical italic theta symbol"
+    "\\vartheta",
+    "𝜗 = \\mathit{\\vartheta} (omlmathit), mathematical italic theta symbol"
   ],
   [
-    "\\mitvarkappa",
-    "mathematical italic kappa symbol"
+    "\\varkappa",
+    "𝜘 mathematical italic kappa symbol"
   ],
   [
-    "\\mitphi",
-    "mathematical italic phi symbol"
+    "\\phi",
+    "𝜙 = \\mathit{\\phi} (omlmathit), mathematical italic phi symbol"
   ],
   [
-    "\\mitvarrho",
-    "mathematical italic rho symbol"
+    "\\varrho",
+    "𝜚 = \\mathit{\\varrho} (omlmathit), mathematical italic rho symbol"
   ],
   [
-    "\\mitvarpi",
-    "mathematical italic pi symbol"
+    "\\varpi",
+    "𝜛 = \\mathit{\\varpi} (omlmathit), mathematical italic pi symbol"
   ],
   [
     "\\mbfitAlpha",
-    "mathematical bold italic capital alpha"
+    "𝜜  mathematical bold italic capital alpha"
   ],
   [
     "\\mbfitBeta",
-    "mathematical bold italic capital beta"
+    "𝜝  mathematical bold italic capital beta"
   ],
   [
-    "\\mbfitGamma",
-    "mathematical bold italic capital gamma"
+    "\\mathbfit{\\Gamma}",
+    "𝜞 = \\mathbold{\\gamma} (fixmath), mathematical bold italic capital gamma"
   ],
   [
-    "\\mbfitDelta",
-    "mathematical bold italic capital delta"
+    "\\mathbfit{\\Delta}",
+    "𝜟 = \\mathbold{\\delta} (fixmath), mathematical bold italic capital delta"
   ],
   [
     "\\mbfitEpsilon",
-    "mathematical bold italic capital epsilon"
+    "𝜠  mathematical bold italic capital epsilon"
   ],
   [
     "\\mbfitZeta",
-    "mathematical bold italic capital zeta"
+    "𝜡  mathematical bold italic capital zeta"
   ],
   [
     "\\mbfitEta",
-    "mathematical bold italic capital eta"
+    "𝜢  mathematical bold italic capital eta"
   ],
   [
-    "\\mbfitTheta",
-    "mathematical bold italic capital theta"
+    "\\mathbfit{\\Theta}",
+    "𝜣 = \\mathbold{\\theta} (fixmath), mathematical bold italic capital theta"
   ],
   [
     "\\mbfitIota",
-    "mathematical bold italic capital iota"
+    "𝜤  mathematical bold italic capital iota"
   ],
   [
     "\\mbfitKappa",
-    "mathematical bold italic capital kappa"
+    "𝜥  mathematical bold italic capital kappa"
   ],
   [
-    "\\mbfitLambda",
-    "mathematical bold italic capital lambda"
+    "\\mathbfit{\\Lambda}",
+    "𝜦 = \\mathbold{\\lambda} (fixmath), mathematical bold italic capital lambda"
   ],
   [
     "\\mbfitMu",
-    "mathematical bold italic capital mu"
+    "𝜧  mathematical bold italic capital mu"
   ],
   [
     "\\mbfitNu",
-    "mathematical bold italic capital nu"
+    "𝜨  mathematical bold italic capital nu"
   ],
   [
-    "\\mbfitXi",
-    "mathematical bold italic capital xi"
+    "\\mathbfit{\\Xi}",
+    "𝜩 = \\mathbold{\\xi} (fixmath), mathematical bold italic capital xi"
   ],
   [
     "\\mbfitOmicron",
-    "mathematical bold italic capital omicron"
+    "𝜪  mathematical bold italic capital omicron"
   ],
   [
-    "\\mbfitPi",
-    "mathematical bold italic capital pi"
+    "\\mathbfit{\\Pi}",
+    "𝜫 = \\mathbold{\\pi} (fixmath), mathematical bold italic capital pi"
   ],
   [
     "\\mbfitRho",
-    "mathematical bold italic capital rho"
+    "𝜬  mathematical bold italic capital rho"
   ],
   [
     "\\mbfitvarTheta",
-    "mathematical bold italic capital theta symbol"
+    "𝜭  mathematical bold italic capital theta symbol"
   ],
   [
-    "\\mbfitSigma",
-    "mathematical bold italic capital sigma"
+    "\\mathbfit{\\Sigma}",
+    "𝜮 = \\mathbold{\\sigma} (fixmath), mathematical bold italic capital sigma"
   ],
   [
     "\\mbfitTau",
-    "mathematical bold italic capital tau"
+    "𝜯  mathematical bold italic capital tau"
   ],
   [
-    "\\mbfitUpsilon",
-    "mathematical bold italic capital upsilon"
+    "\\mathbfit{\\Upsilon}",
+    "𝜰 = \\mathbold{\\upsilon} (fixmath), mathematical bold italic capital upsilon"
   ],
   [
-    "\\mbfitPhi",
-    "mathematical bold italic capital phi"
+    "\\mathbfit{\\Phi}",
+    "𝜱 = \\mathbold{\\phi} (fixmath), mathematical bold italic capital phi"
   ],
   [
     "\\mbfitChi",
-    "mathematical bold italic capital chi"
+    "𝜲  mathematical bold italic capital chi"
   ],
   [
-    "\\mbfitPsi",
-    "mathematical bold italic capital psi"
+    "\\mathbfit{\\Psi}",
+    "𝜳 = \\mathbold{\\psi} (fixmath), mathematical bold italic capital psi"
   ],
   [
-    "\\mbfitOmega",
-    "mathematical bold italic capital omega"
+    "\\mathbfit{\\Omega}",
+    "𝜴 = \\mathbold{\\omega} (fixmath), mathematical bold italic capital omega"
   ],
   [
     "\\mbfitnabla",
-    "mathematical bold italic nabla"
+    "𝜵  mathematical bold italic nabla"
   ],
   [
-    "\\mbfitalpha",
-    "mathematical bold italic small alpha"
+    "\\mathbfit{\\alpha}",
+    "𝜶 = \\mathbold{\\alpha} (fixmath), mathematical bold italic small alpha"
   ],
   [
-    "\\mbfitbeta",
-    "mathematical bold italic small beta"
+    "\\mathbfit{\\beta}",
+    "𝜷 = \\mathbold{\\beta} (fixmath), mathematical bold italic small beta"
   ],
   [
-    "\\mbfitgamma",
-    "mathematical bold italic small gamma"
+    "\\mathbfit{\\gamma}",
+    "𝜸 = \\mathbold{\\gamma} (fixmath), mathematical bold italic small gamma"
   ],
   [
-    "\\mbfitdelta",
-    "mathematical bold italic small delta"
+    "\\mathbfit{\\delta}",
+    "𝜹 = \\mathbold{\\delta} (fixmath), mathematical bold italic small delta"
   ],
   [
-    "\\mbfitvarepsilon",
-    "mathematical bold italic small varepsilon"
+    "\\mathbfit{\\varepsilon}",
+    "𝜺 = \\mathbold{\\varepsilon} (fixmath), mathematical bold italic small epsilon"
   ],
   [
-    "\\mbfitzeta",
-    "mathematical bold italic small zeta"
+    "\\mathbfit{\\zeta}",
+    "𝜻 = \\mathbold{\\zeta} (fixmath), mathematical bold italic small zeta"
   ],
   [
-    "\\mbfiteta",
-    "mathematical bold italic small eta"
+    "\\mathbfit{\\eta}",
+    "𝜼 = \\mathbold{\\eta} (fixmath), mathematical bold italic small eta"
   ],
   [
-    "\\mbfittheta",
-    "mathematical bold italic small theta"
+    "\\mathbfit{\\theta}",
+    "𝜽 = \\mathbold{\\theta} (fixmath), mathematical bold italic small theta"
   ],
   [
-    "\\mbfitiota",
-    "mathematical bold italic small iota"
+    "\\mathbfit{\\iota}",
+    "𝜾 = \\mathbold{\\iota} (fixmath), mathematical bold italic small iota"
   ],
   [
-    "\\mbfitkappa",
-    "mathematical bold italic small kappa"
+    "\\mathbfit{\\kappa}",
+    "𝜿 = \\mathbold{\\kappa} (fixmath), mathematical bold italic small kappa"
   ],
   [
-    "\\mbfitlambda",
-    "mathematical bold italic small lambda"
+    "\\mathbfit{\\lambda}",
+    "𝝀 = \\mathbold{\\lambda} (fixmath), mathematical bold italic small lambda"
   ],
   [
-    "\\mbfitmu",
-    "mathematical bold italic small mu"
+    "\\mathbfit{\\mu}",
+    "𝝁 = \\mathbold{\\mu} (fixmath), mathematical bold italic small mu"
   ],
   [
-    "\\mbfitnu",
-    "mathematical bold italic small nu"
+    "\\mathbfit{\\nu}",
+    "𝝂 = \\mathbold{\\nu} (fixmath), mathematical bold italic small nu"
   ],
   [
-    "\\mbfitxi",
-    "mathematical bold italic small xi"
+    "\\mathbfit{\\xi}",
+    "𝝃 = \\mathbold{\\xi} (fixmath), mathematical bold italic small xi"
   ],
   [
     "\\mbfitomicron",
-    "mathematical bold italic small omicron"
+    "𝝄  mathematical bold italic small omicron"
   ],
   [
-    "\\mbfitpi",
-    "mathematical bold italic small pi"
+    "\\mathbfit{\\pi}",
+    "𝝅 = \\mathbold{\\pi} (fixmath), mathematical bold italic small pi"
   ],
   [
-    "\\mbfitrho",
-    "mathematical bold italic small rho"
+    "\\mathbfit{\\rho}",
+    "𝝆 = \\mathbold{\\rho} (fixmath), mathematical bold italic small rho"
   ],
   [
-    "\\mbfitvarsigma",
-    "mathematical bold italic small final sigma"
+    "\\mathbfit{\\varsigma}",
+    "𝝇 = \\mathbold{\\varsigma} (fixmath), mathematical bold italic small final sigma"
   ],
   [
-    "\\mbfitsigma",
-    "mathematical bold italic small sigma"
+    "\\mathbfit{\\sigma}",
+    "𝝈 = \\mathbold{\\sigma} (fixmath), mathematical bold italic small sigma"
   ],
   [
-    "\\mbfittau",
-    "mathematical bold italic small tau"
+    "\\mathbfit{\\tau}",
+    "𝝉 = \\mathbold{\\tau} (fixmath), mathematical bold italic small tau"
   ],
   [
-    "\\mbfitupsilon",
-    "mathematical bold italic small upsilon"
+    "\\mathbfit{\\upsilon}",
+    "𝝊 = \\mathbold{\\upsilon} (fixmath), mathematical bold italic small upsilon"
   ],
   [
-    "\\mbfitvarphi",
-    "mathematical bold italic small phi"
+    "\\mathbfit{\\varphi}",
+    "𝝋 = \\mathbold{\\varphi} (fixmath), mathematical bold italic small phi"
   ],
   [
-    "\\mbfitchi",
-    "mathematical bold italic small chi"
+    "\\mathbfit{\\chi}",
+    "𝝌 = \\mathbold{\\chi} (fixmath), mathematical bold italic small chi"
   ],
   [
-    "\\mbfitpsi",
-    "mathematical bold italic small psi"
+    "\\mathbfit{\\psi}",
+    "𝝍 = \\mathbold{\\psi} (fixmath), mathematical bold italic small psi"
   ],
   [
-    "\\mbfitomega",
-    "mathematical bold italic small omega"
+    "\\mathbfit{\\omega}",
+    "𝝎 = \\mathbold{\\omega} (fixmath), mathematical bold italic small omega"
   ],
   [
     "\\mbfitpartial",
-    "mathematical bold italic partial differential"
+    "𝝏  mathematical bold italic partial differential"
   ],
   [
-    "\\mbfitepsilon",
-    "mathematical bold italic varepsilon symbol"
+    "\\mathbfit{\\epsilon}",
+    "𝝐 = \\mathbold{\\epsilon} (fixmath), mathematical bold italic epsilon symbol"
   ],
   [
-    "\\mbfitvartheta",
-    "mathematical bold italic theta symbol"
+    "\\mathbfit{\\vartheta}",
+    "𝝑 = \\mathbold{\\vartheta} (fixmath), mathematical bold italic theta symbol"
   ],
   [
     "\\mbfitvarkappa",
-    "mathematical bold italic kappa symbol"
+    "𝝒  mathematical bold italic kappa symbol"
   ],
   [
-    "\\mbfitphi",
-    "mathematical bold italic phi symbol"
+    "\\mathbfit{\\phi}",
+    "𝝓 = \\mathbold{\\phi} (fixmath), mathematical bold italic phi symbol"
   ],
   [
-    "\\mbfitvarrho",
-    "mathematical bold italic rho symbol"
+    "\\mathbfit{\\varrho}",
+    "𝝔 = \\mathbold{\\varrho} (fixmath), mathematical bold italic rho symbol"
   ],
   [
-    "\\mbfitvarpi",
-    "mathematical bold italic pi symbol"
+    "\\mathbfit{\\varpi}",
+    "𝝕 = \\mathbold{\\varpi} (fixmath), mathematical bold italic pi symbol"
   ],
   [
     "\\mbfsansAlpha",
-    "mathematical sans-serif bold capital alpha"
+    "𝝖  mathematical sans-serif bold capital alpha"
   ],
   [
     "\\mbfsansBeta",
-    "mathematical sans-serif bold capital beta"
+    "𝝗  mathematical sans-serif bold capital beta"
   ],
   [
-    "\\mbfsansGamma",
-    "mathematical sans-serif bold capital gamma"
+    "\\mathsfbf{\\Gamma}",
+    "𝝘 mathematical sans-serif bold capital gamma"
   ],
   [
-    "\\mbfsansDelta",
-    "mathematical sans-serif bold capital delta"
+    "\\mathsfbf{\\Delta}",
+    "𝝙 mathematical sans-serif bold capital delta"
   ],
   [
     "\\mbfsansEpsilon",
-    "mathematical sans-serif bold capital epsilon"
+    "𝝚  mathematical sans-serif bold capital epsilon"
   ],
   [
     "\\mbfsansZeta",
-    "mathematical sans-serif bold capital zeta"
+    "𝝛  mathematical sans-serif bold capital zeta"
   ],
   [
     "\\mbfsansEta",
-    "mathematical sans-serif bold capital eta"
+    "𝝜  mathematical sans-serif bold capital eta"
   ],
   [
-    "\\mbfsansTheta",
-    "mathematical sans-serif bold capital theta"
+    "\\mathsfbf{\\Theta}",
+    "𝝝 mathematical sans-serif bold capital theta"
   ],
   [
     "\\mbfsansIota",
-    "mathematical sans-serif bold capital iota"
+    "𝝞  mathematical sans-serif bold capital iota"
   ],
   [
     "\\mbfsansKappa",
-    "mathematical sans-serif bold capital kappa"
+    "𝝟  mathematical sans-serif bold capital kappa"
   ],
   [
-    "\\mbfsansLambda",
-    "mathematical sans-serif bold capital lambda"
+    "\\mathsfbf{\\Lambda}",
+    "𝝠 mathematical sans-serif bold capital lambda"
   ],
   [
     "\\mbfsansMu",
-    "mathematical sans-serif bold capital mu"
+    "𝝡  mathematical sans-serif bold capital mu"
   ],
   [
     "\\mbfsansNu",
-    "mathematical sans-serif bold capital nu"
+    "𝝢  mathematical sans-serif bold capital nu"
   ],
   [
-    "\\mbfsansXi",
-    "mathematical sans-serif bold capital xi"
+    "\\mathsfbf{\\Xi}",
+    "𝝣 mathematical sans-serif bold capital xi"
   ],
   [
     "\\mbfsansOmicron",
-    "mathematical sans-serif bold capital omicron"
+    "𝝤  mathematical sans-serif bold capital omicron"
   ],
   [
-    "\\mbfsansPi",
-    "mathematical sans-serif bold capital pi"
+    "\\mathsfbf{\\Pi}",
+    "𝝥 mathematical sans-serif bold capital pi"
   ],
   [
     "\\mbfsansRho",
-    "mathematical sans-serif bold capital rho"
+    "𝝦  mathematical sans-serif bold capital rho"
   ],
   [
     "\\mbfsansvarTheta",
-    "mathematical sans-serif bold capital theta symbol"
+    "𝝧  mathematical sans-serif bold capital theta symbol"
   ],
   [
-    "\\mbfsansSigma",
-    "mathematical sans-serif bold capital sigma"
+    "\\mathsfbf{\\Sigma}",
+    "𝝨 mathematical sans-serif bold capital sigma"
   ],
   [
     "\\mbfsansTau",
-    "mathematical sans-serif bold capital tau"
+    "𝝩  mathematical sans-serif bold capital tau"
   ],
   [
-    "\\mbfsansUpsilon",
-    "mathematical sans-serif bold capital upsilon"
+    "\\mathsfbf{\\Upsilon}",
+    "𝝪 mathematical sans-serif bold capital upsilon"
   ],
   [
-    "\\mbfsansPhi",
-    "mathematical sans-serif bold capital phi"
+    "\\mathsfbf{\\Phi}",
+    "𝝫 mathematical sans-serif bold capital phi"
   ],
   [
     "\\mbfsansChi",
-    "mathematical sans-serif bold capital chi"
+    "𝝬  mathematical sans-serif bold capital chi"
   ],
   [
-    "\\mbfsansPsi",
-    "mathematical sans-serif bold capital psi"
+    "\\mathsfbf{\\Psi}",
+    "𝝭 mathematical sans-serif bold capital psi"
   ],
   [
-    "\\mbfsansOmega",
-    "mathematical sans-serif bold capital omega"
+    "\\mathsfbf{\\Omega}",
+    "𝝮 mathematical sans-serif bold capital omega"
   ],
   [
     "\\mbfsansnabla",
-    "mathematical sans-serif bold nabla"
+    "𝝯  mathematical sans-serif bold nabla"
   ],
   [
-    "\\mbfsansalpha",
-    "mathematical sans-serif bold small alpha"
+    "\\mathsfbf{\\alpha}",
+    "𝝰 mathematical sans-serif bold small alpha"
   ],
   [
-    "\\mbfsansbeta",
-    "mathematical sans-serif bold small beta"
+    "\\mathsfbf{\\beta}",
+    "𝝱 mathematical sans-serif bold small beta"
   ],
   [
-    "\\mbfsansgamma",
-    "mathematical sans-serif bold small gamma"
+    "\\mathsfbf{\\gamma}",
+    "𝝲 mathematical sans-serif bold small gamma"
   ],
   [
-    "\\mbfsansdelta",
-    "mathematical sans-serif bold small delta"
+    "\\mathsfbf{\\delta}",
+    "𝝳 mathematical sans-serif bold small delta"
   ],
   [
-    "\\mbfsansvarepsilon",
-    "mathematical sans-serif bold small varepsilon"
+    "\\mathsfbf{\\varepsilon}",
+    "𝝴 mathematical sans-serif bold small epsilon"
   ],
   [
-    "\\mbfsanszeta",
-    "mathematical sans-serif bold small zeta"
+    "\\mathsfbf{\\zeta}",
+    "𝝵 mathematical sans-serif bold small zeta"
   ],
   [
-    "\\mbfsanseta",
-    "mathematical sans-serif bold small eta"
+    "\\mathsfbf{\\eta}",
+    "𝝶 mathematical sans-serif bold small eta"
   ],
   [
-    "\\mbfsanstheta",
-    "mathematical sans-serif bold small theta"
+    "\\mathsfbf{\\theta}",
+    "𝝷 mathematical sans-serif bold small theta"
   ],
   [
-    "\\mbfsansiota",
-    "mathematical sans-serif bold small iota"
+    "\\mathsfbf{\\iota}",
+    "𝝸 mathematical sans-serif bold small iota"
   ],
   [
-    "\\mbfsanskappa",
-    "mathematical sans-serif bold small kappa"
+    "\\mathsfbf{\\kappa}",
+    "𝝹 mathematical sans-serif bold small kappa"
   ],
   [
-    "\\mbfsanslambda",
-    "mathematical sans-serif bold small lambda"
+    "\\mathsfbf{\\lambda}",
+    "𝝺 mathematical sans-serif bold small lambda"
   ],
   [
-    "\\mbfsansmu",
-    "mathematical sans-serif bold small mu"
+    "\\mathsfbf{\\mu}",
+    "𝝻 mathematical sans-serif bold small mu"
   ],
   [
-    "\\mbfsansnu",
-    "mathematical sans-serif bold small nu"
+    "\\mathsfbf{\\nu}",
+    "𝝼 mathematical sans-serif bold small nu"
   ],
   [
-    "\\mbfsansxi",
-    "mathematical sans-serif bold small xi"
+    "\\mathsfbf{\\xi}",
+    "𝝽 mathematical sans-serif bold small xi"
   ],
   [
     "\\mbfsansomicron",
-    "mathematical sans-serif bold small omicron"
+    "𝝾  mathematical sans-serif bold small omicron"
   ],
   [
-    "\\mbfsanspi",
-    "mathematical sans-serif bold small pi"
+    "\\mathsfbf{\\pi}",
+    "𝝿 mathematical sans-serif bold small pi"
   ],
   [
-    "\\mbfsansrho",
-    "mathematical sans-serif bold small rho"
+    "\\mathsfbf{\\rho}",
+    "𝞀 mathematical sans-serif bold small rho"
   ],
   [
-    "\\mbfsansvarsigma",
-    "mathematical sans-serif bold small final sigma"
+    "\\mathsfbf{\\varsigma}",
+    "𝞁 mathematical sans-serif bold small final sigma"
   ],
   [
-    "\\mbfsanssigma",
-    "mathematical sans-serif bold small sigma"
+    "\\mathsfbf{\\sigma}",
+    "𝞂 mathematical sans-serif bold small sigma"
   ],
   [
-    "\\mbfsanstau",
-    "mathematical sans-serif bold small tau"
+    "\\mathsfbf{\\tau}",
+    "𝞃 mathematical sans-serif bold small tau"
   ],
   [
-    "\\mbfsansupsilon",
-    "mathematical sans-serif bold small upsilon"
+    "\\mathsfbf{\\upsilon}",
+    "𝞄 mathematical sans-serif bold small upsilon"
   ],
   [
-    "\\mbfsansvarphi",
-    "mathematical sans-serif bold small phi"
+    "\\mathsfbf{\\varphi}",
+    "𝞅 mathematical sans-serif bold small phi"
   ],
   [
-    "\\mbfsanschi",
-    "mathematical sans-serif bold small chi"
+    "\\mathsfbf{\\chi}",
+    "𝞆 mathematical sans-serif bold small chi"
   ],
   [
-    "\\mbfsanspsi",
-    "mathematical sans-serif bold small psi"
+    "\\mathsfbf{\\psi}",
+    "𝞇 mathematical sans-serif bold small psi"
   ],
   [
-    "\\mbfsansomega",
-    "mathematical sans-serif bold small omega"
+    "\\mathsfbf{\\omega}",
+    "𝞈 mathematical sans-serif bold small omega"
   ],
   [
     "\\mbfsanspartial",
-    "mathematical sans-serif bold partial differential"
+    "𝞉  mathematical sans-serif bold partial differential"
   ],
   [
-    "\\mbfsansepsilon",
-    "mathematical sans-serif bold varepsilon symbol"
+    "\\mathsfbf{\\epsilon}",
+    "𝞊 mathematical sans-serif bold epsilon symbol"
   ],
   [
-    "\\mbfsansvartheta",
-    "mathematical sans-serif bold theta symbol"
+    "\\mathsfbf{\\vartheta}",
+    "𝞋 mathematical sans-serif bold theta symbol"
   ],
   [
     "\\mbfsansvarkappa",
-    "mathematical sans-serif bold kappa symbol"
+    "𝞌  mathematical sans-serif bold kappa symbol"
   ],
   [
-    "\\mbfsansphi",
-    "mathematical sans-serif bold phi symbol"
+    "\\mathsfbf{\\phi}",
+    "𝞍 mathematical sans-serif bold phi symbol"
   ],
   [
-    "\\mbfsansvarrho",
-    "mathematical sans-serif bold rho symbol"
+    "\\mathsfbf{\\varrho}",
+    "𝞎 mathematical sans-serif bold rho symbol"
   ],
   [
-    "\\mbfsansvarpi",
-    "mathematical sans-serif bold pi symbol"
+    "\\mathsfbf{\\varpi}",
+    "𝞏 mathematical sans-serif bold pi symbol"
   ],
   [
     "\\mbfitsansAlpha",
-    "mathematical sans-serif bold italic capital alpha"
+    "𝞐  mathematical sans-serif bold italic capital alpha"
   ],
   [
     "\\mbfitsansBeta",
-    "mathematical sans-serif bold italic capital beta"
+    "𝞑  mathematical sans-serif bold italic capital beta"
   ],
   [
-    "\\mbfitsansGamma",
-    "mathematical sans-serif bold italic capital gamma"
+    "\\mathsfbfit{\\Gamma}",
+    "𝞒 mathematical sans-serif bold italic capital gamma"
   ],
   [
-    "\\mbfitsansDelta",
-    "mathematical sans-serif bold italic capital delta"
+    "\\mathsfbfit{\\Delta}",
+    "𝞓 mathematical sans-serif bold italic capital delta"
   ],
   [
     "\\mbfitsansEpsilon",
-    "mathematical sans-serif bold italic capital epsilon"
+    "𝞔  mathematical sans-serif bold italic capital epsilon"
   ],
   [
     "\\mbfitsansZeta",
-    "mathematical sans-serif bold italic capital zeta"
+    "𝞕  mathematical sans-serif bold italic capital zeta"
   ],
   [
     "\\mbfitsansEta",
-    "mathematical sans-serif bold italic capital eta"
+    "𝞖  mathematical sans-serif bold italic capital eta"
   ],
   [
-    "\\mbfitsansTheta",
-    "mathematical sans-serif bold italic capital theta"
+    "\\mathsfbfit{\\Theta}",
+    "𝞗 mathematical sans-serif bold italic capital theta"
   ],
   [
     "\\mbfitsansIota",
-    "mathematical sans-serif bold italic capital iota"
+    "𝞘  mathematical sans-serif bold italic capital iota"
   ],
   [
     "\\mbfitsansKappa",
-    "mathematical sans-serif bold italic capital kappa"
+    "𝞙  mathematical sans-serif bold italic capital kappa"
   ],
   [
-    "\\mbfitsansLambda",
-    "mathematical sans-serif bold italic capital lambda"
+    "\\mathsfbfit{\\Lambda}",
+    "𝞚 mathematical sans-serif bold italic capital lambda"
   ],
   [
     "\\mbfitsansMu",
-    "mathematical sans-serif bold italic capital mu"
+    "𝞛  mathematical sans-serif bold italic capital mu"
   ],
   [
     "\\mbfitsansNu",
-    "mathematical sans-serif bold italic capital nu"
+    "𝞜  mathematical sans-serif bold italic capital nu"
   ],
   [
-    "\\mbfitsansXi",
-    "mathematical sans-serif bold italic capital xi"
+    "\\mathsfbfit{\\Xi}",
+    "𝞝 mathematical sans-serif bold italic capital xi"
   ],
   [
     "\\mbfitsansOmicron",
-    "mathematical sans-serif bold italic capital omicron"
+    "𝞞  mathematical sans-serif bold italic capital omicron"
   ],
   [
-    "\\mbfitsansPi",
-    "mathematical sans-serif bold italic capital pi"
+    "\\mathsfbfit{\\Pi}",
+    "𝞟 mathematical sans-serif bold italic capital pi"
   ],
   [
     "\\mbfitsansRho",
-    "mathematical sans-serif bold italic capital rho"
+    "𝞠  mathematical sans-serif bold italic capital rho"
   ],
   [
     "\\mbfitsansvarTheta",
-    "mathematical sans-serif bold italic capital theta symbol"
+    "𝞡  mathematical sans-serif bold italic capital theta symbol"
   ],
   [
-    "\\mbfitsansSigma",
-    "mathematical sans-serif bold italic capital sigma"
+    "\\mathsfbfit{\\Sigma}",
+    "𝞢 mathematical sans-serif bold italic capital sigma"
   ],
   [
     "\\mbfitsansTau",
-    "mathematical sans-serif bold italic capital tau"
+    "𝞣  mathematical sans-serif bold italic capital tau"
   ],
   [
-    "\\mbfitsansUpsilon",
-    "mathematical sans-serif bold italic capital upsilon"
+    "\\mathsfbfit{\\Upsilon}",
+    "𝞤 mathematical sans-serif bold italic capital upsilon"
   ],
   [
-    "\\mbfitsansPhi",
-    "mathematical sans-serif bold italic capital phi"
+    "\\mathsfbfit{\\Phi}",
+    "𝞥 mathematical sans-serif bold italic capital phi"
   ],
   [
     "\\mbfitsansChi",
-    "mathematical sans-serif bold italic capital chi"
+    "𝞦  mathematical sans-serif bold italic capital chi"
   ],
   [
-    "\\mbfitsansPsi",
-    "mathematical sans-serif bold italic capital psi"
+    "\\mathsfbfit{\\Psi}",
+    "𝞧 mathematical sans-serif bold italic capital psi"
   ],
   [
-    "\\mbfitsansOmega",
-    "mathematical sans-serif bold italic capital omega"
+    "\\mathsfbfit{\\Omega}",
+    "𝞨 mathematical sans-serif bold italic capital omega"
   ],
   [
     "\\mbfitsansnabla",
-    "mathematical sans-serif bold italic nabla"
+    "𝞩  mathematical sans-serif bold italic nabla"
   ],
   [
-    "\\mbfitsansalpha",
-    "mathematical sans-serif bold italic small alpha"
+    "\\mathsfbfit{\\alpha}",
+    "𝞪 mathematical sans-serif bold italic small alpha"
   ],
   [
-    "\\mbfitsansbeta",
-    "mathematical sans-serif bold italic small beta"
+    "\\mathsfbfit{\\beta}",
+    "𝞫 mathematical sans-serif bold italic small beta"
   ],
   [
-    "\\mbfitsansgamma",
-    "mathematical sans-serif bold italic small gamma"
+    "\\mathsfbfit{\\gamma}",
+    "𝞬 mathematical sans-serif bold italic small gamma"
   ],
   [
-    "\\mbfitsansdelta",
-    "mathematical sans-serif bold italic small delta"
+    "\\mathsfbfit{\\delta}",
+    "𝞭 mathematical sans-serif bold italic small delta"
   ],
   [
-    "\\mbfitsansvarepsilon",
-    "mathematical sans-serif bold italic small varepsilon"
+    "\\mathsfbfit{\\varepsilon}",
+    "𝞮 mathematical sans-serif bold italic small epsilon"
   ],
   [
-    "\\mbfitsanszeta",
-    "mathematical sans-serif bold italic small zeta"
+    "\\mathsfbfit{\\zeta}",
+    "𝞯 mathematical sans-serif bold italic small zeta"
   ],
   [
-    "\\mbfitsanseta",
-    "mathematical sans-serif bold italic small eta"
+    "\\mathsfbfit{\\eta}",
+    "𝞰 mathematical sans-serif bold italic small eta"
   ],
   [
-    "\\mbfitsanstheta",
-    "mathematical sans-serif bold italic small theta"
+    "\\mathsfbfit{\\theta}",
+    "𝞱 mathematical sans-serif bold italic small theta"
   ],
   [
-    "\\mbfitsansiota",
-    "mathematical sans-serif bold italic small iota"
+    "\\mathsfbfit{\\iota}",
+    "𝞲 mathematical sans-serif bold italic small iota"
   ],
   [
-    "\\mbfitsanskappa",
-    "mathematical sans-serif bold italic small kappa"
+    "\\mathsfbfit{\\kappa}",
+    "𝞳 mathematical sans-serif bold italic small kappa"
   ],
   [
-    "\\mbfitsanslambda",
-    "mathematical sans-serif bold italic small lambda"
+    "\\mathsfbfit{\\lambda}",
+    "𝞴 mathematical sans-serif bold italic small lambda"
   ],
   [
-    "\\mbfitsansmu",
-    "mathematical sans-serif bold italic small mu"
+    "\\mathsfbfit{\\mu}",
+    "𝞵 mathematical sans-serif bold italic small mu"
   ],
   [
-    "\\mbfitsansnu",
-    "mathematical sans-serif bold italic small nu"
+    "\\mathsfbfit{\\nu}",
+    "𝞶 mathematical sans-serif bold italic small nu"
   ],
   [
-    "\\mbfitsansxi",
-    "mathematical sans-serif bold italic small xi"
+    "\\mathsfbfit{\\xi}",
+    "𝞷 mathematical sans-serif bold italic small xi"
   ],
   [
     "\\mbfitsansomicron",
-    "mathematical sans-serif bold italic small omicron"
+    "𝞸  mathematical sans-serif bold italic small omicron"
   ],
   [
-    "\\mbfitsanspi",
-    "mathematical sans-serif bold italic small pi"
+    "\\mathsfbfit{\\pi}",
+    "𝞹 mathematical sans-serif bold italic small pi"
   ],
   [
-    "\\mbfitsansrho",
-    "mathematical sans-serif bold italic small rho"
+    "\\mathsfbfit{\\rho}",
+    "𝞺 mathematical sans-serif bold italic small rho"
   ],
   [
-    "\\mbfitsansvarsigma",
-    "mathematical sans-serif bold italic small final sigma"
+    "\\mathsfbfit{\\varsigma}",
+    "𝞻 mathematical sans-serif bold italic small final sigma"
   ],
   [
-    "\\mbfitsanssigma",
-    "mathematical sans-serif bold italic small sigma"
+    "\\mathsfbfit{\\sigma}",
+    "𝞼 mathematical sans-serif bold italic small sigma"
   ],
   [
-    "\\mbfitsanstau",
-    "mathematical sans-serif bold italic small tau"
+    "\\mathsfbfit{\\tau}",
+    "𝞽 mathematical sans-serif bold italic small tau"
   ],
   [
-    "\\mbfitsansupsilon",
-    "mathematical sans-serif bold italic small upsilon"
+    "\\mathsfbfit{\\upsilon}",
+    "𝞾 mathematical sans-serif bold italic small upsilon"
   ],
   [
-    "\\mbfitsansvarphi",
-    "mathematical sans-serif bold italic small phi"
+    "\\mathsfbfit{\\varphi}",
+    "𝞿 mathematical sans-serif bold italic small phi"
   ],
   [
-    "\\mbfitsanschi",
-    "mathematical sans-serif bold italic small chi"
+    "\\mathsfbfit{\\chi}",
+    "𝟀 mathematical sans-serif bold italic small chi"
   ],
   [
-    "\\mbfitsanspsi",
-    "mathematical sans-serif bold italic small psi"
+    "\\mathsfbfit{\\psi}",
+    "𝟁 mathematical sans-serif bold italic small psi"
   ],
   [
-    "\\mbfitsansomega",
-    "mathematical sans-serif bold italic small omega"
+    "\\mathsfbfit{\\omega}",
+    "𝟂 mathematical sans-serif bold italic small omega"
   ],
   [
     "\\mbfitsanspartial",
-    "mathematical sans-serif bold italic partial differential"
+    "𝟃  mathematical sans-serif bold italic partial differential"
   ],
   [
-    "\\mbfitsansepsilon",
-    "mathematical sans-serif bold italic varepsilon symbol"
+    "\\mathsfbfit{\\epsilon}",
+    "𝟄 mathematical sans-serif bold italic epsilon symbol"
   ],
   [
-    "\\mbfitsansvartheta",
-    "mathematical sans-serif bold italic theta symbol"
+    "\\mathsfbfit{\\vartheta}",
+    "𝟅 mathematical sans-serif bold italic theta symbol"
   ],
   [
     "\\mbfitsansvarkappa",
-    "mathematical sans-serif bold italic kappa symbol"
+    "𝟆  mathematical sans-serif bold italic kappa symbol"
   ],
   [
-    "\\mbfitsansphi",
-    "mathematical sans-serif bold italic phi symbol"
+    "\\mathsfbfit{\\phi}",
+    "𝟇 mathematical sans-serif bold italic phi symbol"
   ],
   [
-    "\\mbfitsansvarrho",
-    "mathematical sans-serif bold italic rho symbol"
+    "\\mathsfbfit{\\varrho}",
+    "𝟈 mathematical sans-serif bold italic rho symbol"
   ],
   [
-    "\\mbfitsansvarpi",
-    "mathematical sans-serif bold italic pi symbol"
+    "\\mathsfbfit{\\varpi}",
+    "𝟉 mathematical sans-serif bold italic pi symbol"
   ],
   [
     "\\mbfDigamma",
-    "mathematical bold capital digamma"
+    "𝟊  mathematical bold capital digamma"
   ],
   [
     "\\mbfdigamma",
-    "mathematical bold small digamma"
+    "𝟋  mathematical bold small digamma"
   ],
   [
-    "\\mbfzero",
-    "mathematical bold digit 0"
+    "\\mathbf{0}",
+    "𝟎 mathematical bold digit 0"
   ],
   [
-    "\\mbfone",
-    "mathematical bold digit 1"
+    "\\mathbf{1}",
+    "𝟏 mathematical bold digit 1"
   ],
   [
-    "\\mbftwo",
-    "mathematical bold digit 2"
+    "\\mathbf{2}",
+    "𝟐 mathematical bold digit 2"
   ],
   [
-    "\\mbfthree",
-    "mathematical bold digit 3"
+    "\\mathbf{3}",
+    "𝟑 mathematical bold digit 3"
   ],
   [
-    "\\mbffour",
-    "mathematical bold digit 4"
+    "\\mathbf{4}",
+    "𝟒 mathematical bold digit 4"
   ],
   [
-    "\\mbffive",
-    "mathematical bold digit 5"
+    "\\mathbf{5}",
+    "𝟓 mathematical bold digit 5"
   ],
   [
-    "\\mbfsix",
-    "mathematical bold digit 6"
+    "\\mathbf{6}",
+    "𝟔 mathematical bold digit 6"
   ],
   [
-    "\\mbfseven",
-    "mathematical bold digit 7"
+    "\\mathbf{7}",
+    "𝟕 mathematical bold digit 7"
   ],
   [
-    "\\mbfeight",
-    "mathematical bold digit 8"
+    "\\mathbf{8}",
+    "𝟖 mathematical bold digit 8"
   ],
   [
-    "\\mbfnine",
-    "mathematical bold digit 9"
+    "\\mathbf{9}",
+    "𝟗 mathematical bold digit 9"
   ],
   [
-    "\\Bbbzero",
-    "mathematical double-struck digit 0"
+    "\\mathbb{0}",
+    "𝟘 mathematical double-struck digit 0"
   ],
   [
-    "\\Bbbone",
-    "mathematical double-struck digit 1"
+    "\\mathbb{1}",
+    "𝟙 = \\mathds{1} (dsfont), mathematical double-struck digit 1"
   ],
   [
-    "\\Bbbtwo",
-    "mathematical double-struck digit 2"
+    "\\mathbb{2}",
+    "𝟚 mathematical double-struck digit 2"
   ],
   [
-    "\\Bbbthree",
-    "mathematical double-struck digit 3"
+    "\\mathbb{3}",
+    "𝟛 mathematical double-struck digit 3"
   ],
   [
-    "\\Bbbfour",
-    "mathematical double-struck digit 4"
+    "\\mathbb{4}",
+    "𝟜 mathematical double-struck digit 4"
   ],
   [
-    "\\Bbbfive",
-    "mathematical double-struck digit 5"
+    "\\mathbb{5}",
+    "𝟝 mathematical double-struck digit 5"
   ],
   [
-    "\\Bbbsix",
-    "mathematical double-struck digit 6"
+    "\\mathbb{6}",
+    "𝟞 mathematical double-struck digit 6"
   ],
   [
-    "\\Bbbseven",
-    "mathematical double-struck digit 7"
+    "\\mathbb{7}",
+    "𝟟 mathematical double-struck digit 7"
   ],
   [
-    "\\Bbbeight",
-    "mathematical double-struck digit 8"
+    "\\mathbb{8}",
+    "𝟠 mathematical double-struck digit 8"
   ],
   [
-    "\\Bbbnine",
-    "mathematical double-struck digit 9"
+    "\\mathbb{9}",
+    "𝟡 mathematical double-struck digit 9"
   ],
   [
-    "\\msanszero",
-    "mathematical sans-serif digit 0"
+    "\\mathsf{0}",
+    "𝟢 mathematical sans-serif digit 0"
   ],
   [
-    "\\msansone",
-    "mathematical sans-serif digit 1"
+    "\\mathsf{1}",
+    "𝟣 mathematical sans-serif digit 1"
   ],
   [
-    "\\msanstwo",
-    "mathematical sans-serif digit 2"
+    "\\mathsf{2}",
+    "𝟤 mathematical sans-serif digit 2"
   ],
   [
-    "\\msansthree",
-    "mathematical sans-serif digit 3"
+    "\\mathsf{3}",
+    "𝟥 mathematical sans-serif digit 3"
   ],
   [
-    "\\msansfour",
-    "mathematical sans-serif digit 4"
+    "\\mathsf{4}",
+    "𝟦 mathematical sans-serif digit 4"
   ],
   [
-    "\\msansfive",
-    "mathematical sans-serif digit 5"
+    "\\mathsf{5}",
+    "𝟧 mathematical sans-serif digit 5"
   ],
   [
-    "\\msanssix",
-    "mathematical sans-serif digit 6"
+    "\\mathsf{6}",
+    "𝟨 mathematical sans-serif digit 6"
   ],
   [
-    "\\msansseven",
-    "mathematical sans-serif digit 7"
+    "\\mathsf{7}",
+    "𝟩 mathematical sans-serif digit 7"
   ],
   [
-    "\\msanseight",
-    "mathematical sans-serif digit 8"
+    "\\mathsf{8}",
+    "𝟪 mathematical sans-serif digit 8"
   ],
   [
-    "\\msansnine",
-    "mathematical sans-serif digit 9"
+    "\\mathsf{9}",
+    "𝟫 mathematical sans-serif digit 9"
   ],
   [
-    "\\mbfsanszero",
-    "mathematical sans-serif bold digit 0"
+    "\\mathsfbf{0}",
+    "𝟬 mathematical sans-serif bold digit 0"
   ],
   [
-    "\\mbfsansone",
-    "mathematical sans-serif bold digit 1"
+    "\\mathsfbf{1}",
+    "𝟭 mathematical sans-serif bold digit 1"
   ],
   [
-    "\\mbfsanstwo",
-    "mathematical sans-serif bold digit 2"
+    "\\mathsfbf{2}",
+    "𝟮 mathematical sans-serif bold digit 2"
   ],
   [
-    "\\mbfsansthree",
-    "mathematical sans-serif bold digit 3"
+    "\\mathsfbf{3}",
+    "𝟯 mathematical sans-serif bold digit 3"
   ],
   [
-    "\\mbfsansfour",
-    "mathematical sans-serif bold digit 4"
+    "\\mathsfbf{4}",
+    "𝟰 mathematical sans-serif bold digit 4"
   ],
   [
-    "\\mbfsansfive",
-    "mathematical sans-serif bold digit 5"
+    "\\mathsfbf{5}",
+    "𝟱 mathematical sans-serif bold digit 5"
   ],
   [
-    "\\mbfsanssix",
-    "mathematical sans-serif bold digit 6"
+    "\\mathsfbf{6}",
+    "𝟲 mathematical sans-serif bold digit 6"
   ],
   [
-    "\\mbfsansseven",
-    "mathematical sans-serif bold digit 7"
+    "\\mathsfbf{7}",
+    "𝟳 mathematical sans-serif bold digit 7"
   ],
   [
-    "\\mbfsanseight",
-    "mathematical sans-serif bold digit 8"
+    "\\mathsfbf{8}",
+    "𝟴 mathematical sans-serif bold digit 8"
   ],
   [
-    "\\mbfsansnine",
-    "mathematical sans-serif bold digit 9"
+    "\\mathsfbf{9}",
+    "𝟵 mathematical sans-serif bold digit 9"
   ],
   [
-    "\\mttzero",
-    "mathematical monospace digit 0"
+    "\\mathtt{0}",
+    "𝟶 mathematical monospace digit 0"
   ],
   [
-    "\\mttone",
-    "mathematical monospace digit 1"
+    "\\mathtt{1}",
+    "𝟷 mathematical monospace digit 1"
   ],
   [
-    "\\mtttwo",
-    "mathematical monospace digit 2"
+    "\\mathtt{2}",
+    "𝟸 mathematical monospace digit 2"
   ],
   [
-    "\\mttthree",
-    "mathematical monospace digit 3"
+    "\\mathtt{3}",
+    "𝟹 mathematical monospace digit 3"
   ],
   [
-    "\\mttfour",
-    "mathematical monospace digit 4"
+    "\\mathtt{4}",
+    "𝟺 mathematical monospace digit 4"
   ],
   [
-    "\\mttfive",
-    "mathematical monospace digit 5"
+    "\\mathtt{5}",
+    "𝟻 mathematical monospace digit 5"
   ],
   [
-    "\\mttsix",
-    "mathematical monospace digit 6"
+    "\\mathtt{6}",
+    "𝟼 mathematical monospace digit 6"
   ],
   [
-    "\\mttseven",
-    "mathematical monospace digit 7"
+    "\\mathtt{7}",
+    "𝟽 mathematical monospace digit 7"
   ],
   [
-    "\\mtteight",
-    "mathematical monospace digit 8"
+    "\\mathtt{8}",
+    "𝟾 mathematical monospace digit 8"
   ],
   [
-    "\\mttnine",
-    "mathematical monospace digit 9"
-  ],
-  [
-    "\\arabicmaj",
-    "arabic mathematical operator meem with hah with tatweel"
-  ],
-  [
-    "\\arabichad",
-    "arabic mathematical operator hah with dal"
+    "\\mathtt{9}",
+    "𝟿 mathematical monospace digit 9"
   ]
 ]


### PR DESCRIPTION
This completely changes the source for the latex.json. 

This [command list](https://milde.users.sourceforge.net/LUCR/Math/data/unimathsymbols.txt) includes the matching unicode characters for each command.

That lets you see what you will be entering which makes it much easier to find what you are looking for.

I also updated the accreditation in the readme.